### PR TITLE
Chrome on linux

### DIFF
--- a/gpii/node_modules/flowManager/test/data/solutions.reporter.payload.example.json
+++ b/gpii/node_modules/flowManager/test/data/solutions.reporter.payload.example.json
@@ -51,13 +51,13 @@
             "start": [
                 {
                     "type": "gpii.launch.exec",
-                    "command": "firefox http://ec2-107-21-143-113.compute-1.amazonaws.com:8080/demos/Mammals.html?token=${{userToken}}"
+                    "command": "google-chrome http://ec2-107-21-143-113.compute-1.amazonaws.com:8080/demos/Mammals.html?token=${{userToken}}"
                 }
             ],
             "stop": [
                 {
                     "type": "gpii.launch.exec",
-                    "command": "pkill firefox"
+                    "command": "pkill -2 chrome"
                 }
             ]
         }
@@ -113,13 +113,13 @@
             "start": [
                 {
                     "type": "gpii.launch.exec",
-                    "command": "firefox http://easy1234.org/user/${{userToken}}"
+                    "command": "google-chrome http://easy1234.org/user/${{userToken}}"
                 }
             ],
             "stop": [
                 {
                     "type": "gpii.launch.exec",
-                    "command": "pkill firefox"
+                    "command": "pkill -2 chrome"
                 }
             ]
         }
@@ -175,13 +175,13 @@
             "start": [
                 {
                     "type": "gpii.launch.exec",
-                    "command": "firefox http://khdm.info/sudan/"
+                    "command": "google-chrome http://khdm.info/sudan/"
                 }
             ],
             "stop": [
                 {
                     "type": "gpii.launch.exec",
-                    "command": "pkill firefox"
+                    "command": "pkill -2 chrome"
                 }
             ]
         }
@@ -237,13 +237,13 @@
             "start": [
                 {
                     "type": "gpii.launch.exec",
-                    "command": "firefox http://webanywhere.cs.washington.edu/beta/?starting_url=http://ec2-107-21-143-113.compute-1.amazonaws.com:8080/demos/Mammals.html?token=${{userToken}}"
+                    "command": "google-chrome http://webanywhere.cs.washington.edu/beta/?starting_url=http://ec2-107-21-143-113.compute-1.amazonaws.com:8080/demos/Mammals.html?token=${{userToken}}"
                 }
             ],
             "stop": [
                 {
                     "type": "gpii.launch.exec",
-                    "command": "pkill firefox"
+                    "command": "pkill -2 chrome"
                 }
             ]
         }


### PR DESCRIPTION
This pull request switches from Firefox to Chrome (eek) on Linux in order to provide a smoother user experience. The issue I was facing was due to the fact that Firefox apparently doesn't correctly respond to UNIX signals when it is killed from the command line. As a result, it always shows the "This is embarrassing..." page when you next start Firefox after having killed it.

To make this work, you'll need to install Chrome on the Fedora machines, which seems like a terribly sad thing.
