### PR TITLE
Switches web solutions to Chrome (eek) on Linux.

### DIFF
--- a/gpii/node_modules/flowManager/test/data/solutions.reporter.payload.example.json
+++ b/gpii/node_modules/flowManager/test/data/solutions.reporter.payload.example.json
@@ -51,13 +51,13 @@
             "start": [
                 {
                     "type": "gpii.launch.exec",
-                    "command": "firefox http://ec2-107-21-143-113.compute-1.amazonaws.com:8080/demos/Mammals.html?token=${{userToken}}"
+                    "command": "google-chrome http://ec2-107-21-143-113.compute-1.amazonaws.com:8080/demos/Mammals.html?token=${{userToken}}"
                 }
             ],
             "stop": [
                 {
                     "type": "gpii.launch.exec",
-                    "command": "pkill firefox"
+                    "command": "pkill -2 chrome"
                 }
             ]
         }
@@ -113,13 +113,13 @@
             "start": [
                 {
                     "type": "gpii.launch.exec",
-                    "command": "firefox http://easy1234.org/user/${{userToken}}"
+                    "command": "google-chrome http://easy1234.org/user/${{userToken}}"
                 }
             ],
             "stop": [
                 {
                     "type": "gpii.launch.exec",
-                    "command": "pkill firefox"
+                    "command": "pkill -2 chrome"
                 }
             ]
         }
@@ -175,13 +175,13 @@
             "start": [
                 {
                     "type": "gpii.launch.exec",
-                    "command": "firefox http://khdm.info/sudan/"
+                    "command": "google-chrome http://khdm.info/sudan/"
                 }
             ],
             "stop": [
                 {
                     "type": "gpii.launch.exec",
-                    "command": "pkill firefox"
+                    "command": "pkill -2 chrome"
                 }
             ]
         }
@@ -237,13 +237,13 @@
             "start": [
                 {
                     "type": "gpii.launch.exec",
-                    "command": "firefox http://webanywhere.cs.washington.edu/beta/?starting_url=http://ec2-107-21-143-113.compute-1.amazonaws.com:8080/demos/Mammals.html?token=${{userToken}}"
+                    "command": "google-chrome http://webanywhere.cs.washington.edu/beta/?starting_url=http://ec2-107-21-143-113.compute-1.amazonaws.com:8080/demos/Mammals.html?token=${{userToken}}"
                 }
             ],
             "stop": [
                 {
                     "type": "gpii.launch.exec",
-                    "command": "pkill firefox"
+                    "command": "pkill -2 chrome"
                 }
             ]
         }


### PR DESCRIPTION
The reason for this changes is that Firefox doesn't correctly listen to Unix signals when killed from the command line, so it always ends up apologizing for it in the next session.

This change isn't strictly necessary, but it does offer a somewhat better user experience (much to my chagrin). If you do choose this approach, you'll need to install the Chrome yum package first.
