### PR TITLE
GPII-15: Updates all current personas to the new application-specific block format.

### DIFF
--- a/examples/preferences/accessforall-with-application-specific.json
+++ b/examples/preferences/accessforall-with-application-specific.json
@@ -1,0 +1,30 @@
+{
+    "display": {
+        "screenEnhancement": {
+            "fontSize": 24,
+            "magnification": 2.0,
+            "tracking": "mouse",
+            "invertImages": true,
+            "showCrosshairs": true
+        }
+    },
+    
+    "control": {
+        "keyboardEnhancement": {
+            "stickyKeys": true
+        }
+    },
+    
+    "-provisional-languageAssistance": {
+        "applications": {
+            "com.texthelp.readWriteGold": {
+                "name": "Read Write Gold",
+                "priority": 100,
+                "parameters": {
+                    "ApplicationSettings.AppBar.LargeIcons.$t": true,
+                    "ApplicationSettings.AppBar.optToolbarLargeIcons.$t": true
+                }
+            }
+        }
+    }
+}

--- a/gpii/node_modules/deviceReporter/src/installedSolutions.json
+++ b/gpii/node_modules/deviceReporter/src/installedSolutions.json
@@ -1,19 +1,77 @@
 [
     {
         "id": "org.gnome.desktop.interface"
-    }, {
+    },
+    
+    {
         "id": "org.gnome.nautilus"
-    }, {
+    },
+    
+    {
         "id": "org.gnome.desktop.a11y.keyboard"
-    }, {
+    },
+    
+    {
+        "id": "org.gnome.desktop.a11y.caribou-keyboard"
+    },
+    
+    {
         "id": "org.gnome.orca"
-    }, {
+    },
+    
+    {
         "id": "org.gnome.desktop.a11y.magnifier"
-    }, {
+    },
+    
+    {
         "id": "com.microsoft.windows.magnifier"
-    }, {
+    },
+    
+    {
         "id": "com.microsoft.windows.onscreenKeyboard"
-    }, {
+    },
+    
+    {
         "id": "nvda.screenReader"
+    },
+    
+    {
+        "id": "fluid.uiOptions.windows"
+    },
+    
+    {
+        "id": "fluid.uiOptions.linux"
+    },
+    
+    {
+        "id": "org.gnome.desktop.interface"
+    },
+    
+    {
+        "id": "org.gnome.nautilus"
+    },
+    
+    {
+        "id": "trace.easyOne.communicator.windows"
+    },
+    
+    {
+        "id": "trace.easyOne.communicator.linux"
+    },
+    
+    {
+        "id": "trace.easyOne.sudan.windows"
+    },
+    
+    {
+        "id": "trace.easyOne.sudan.linux"
+    },
+    
+    {
+        "id": "webinsight.webAnywhere.windows"
+    },
+    
+    {
+        "id": "webinsight.webAnywhere.linux"
     }
 ]

--- a/gpii/node_modules/flowManager/test/data/solutions.reporter.payload.example.json
+++ b/gpii/node_modules/flowManager/test/data/solutions.reporter.payload.example.json
@@ -17,7 +17,9 @@
                     "hKey": "HKEY_CURRENT_USER",
                     "path": "Software\\Microsoft\\ScreenMagnifier"
                 },
-                "capabilities": [ "display.screenEnhancement.screenMagnification.applications.com\\.microsoft\\.windows\\.magnifier.name" ],
+                "capabilities": [
+                    "display.screenEnhancement.screenMagnification.applications.com\\.microsoft\\.windows\\.magnifier.name"
+                ],
                 "capabilitiesTransformations": {
                     "Magnification": {
                         "expander": {
@@ -92,6 +94,7 @@
             ]
         }
     },
+    
     {
         "name": "GNOME Shell Magnifier",
         "id": "org.gnome.desktop.a11y.magnifier",
@@ -109,7 +112,9 @@
                 "options": {
                     "schema": "org.gnome.desktop.a11y.magnifier"
                 },
-                "capabilities": [ "display.screenMagnification.applications.org\\.gnome\\.desktop\\.a11y\\.magnifier.name" ],
+                "capabilities": [
+                    "display.screenEnhancement.screenMagnification.applications.org\\.gnome\\.desktop\\.a11y\\.magnifier.name" 
+                ],
                 "capabilitiesTransformations": {
                     "mag-factor": "display.screenEnhancement.magnification",
                     "show-cross-hairs": "display.screenEnhancement.showCrosshairs",
@@ -144,6 +149,7 @@
             ]
         }
     },
+    
     {
         "name": "UI Options",
         "id": "fluid.uiOptions.windows",
@@ -181,7 +187,8 @@
                 }
             ]
         }
-    }, 
+    },
+        
     {
         "name": "UI Options",
         "id": "fluid.uiOptions.linux",
@@ -220,6 +227,7 @@
             ]
         }
     },
+    
     {
         "name": "GNOME Interface Settings",
         "id": "org.gnome.desktop.interface",
@@ -254,6 +262,7 @@
             "stop": [ "restoreSettings" ]
         }
     },
+    
     {
         "name": "GNOME Nautilus Settings",
         "id": "org.gnome.nautilus",
@@ -281,7 +290,9 @@
             "start": [ "setSettings" ],
             "stop": [ "restoreSettings" ]
         }
-    }, {
+    },
+    
+    {
         "name": "GNOME Caribou Onscreen Keyboard",
         "id": "org.gnome.desktop.a11y.caribou-keyboard",
         "contexts": {
@@ -313,7 +324,9 @@
                 }
             ]
         }
-    }, {
+    },
+    
+    {
         "name": "GNOME Shell Keyboard Settings",
         "id": "org.gnome.desktop.a11y.keyboard",
         "contexts": {
@@ -375,7 +388,9 @@
             "start": [ "setSettings" ],
             "stop": [ "restoreSettings" ]
         }
-    }, {
+    },
+    
+    {
         "name": "Windows Built-in Onscreen Keyboard",
         "id": "com.microsoft.windows.onscreenKeyboard",
         "contexts": {
@@ -409,7 +424,9 @@
                 }
             ]
         }
-    }, {
+    },
+    
+    {
         "name": "ORCA Screen Reader",
         "id": "org.gnome.orca",
         "contexts": {
@@ -441,7 +458,9 @@
                 }
             ]
         }
-    }, {
+    },
+    
+    {
         "name": "NVDA Screen Reader",
         "id": "nvda.screenReader",
         "contexts": {
@@ -474,6 +493,223 @@
                 },{
                     "type": "gpii.launch.exec",
                     "command": "${{environment}.SystemRoot}\\System32\\taskkill.exe /f /im nvda.exe"
+                }
+            ]
+        }
+    },     
+    
+    {
+        "name": "EasyOne Communicator Windows",
+        "id": "trace.easyOne.communicator.windows",
+        "contexts": {
+            "OS": [
+                {
+                    "id": "win32",
+                    "version": ">=5.0"
+                }
+            ]
+        },
+        
+        "settingsHandlers": [
+            {
+                "type": "gpii.settingsHandlers.noSettings",
+                "capabilities": [
+                    "content.simplification",
+                    "content.simplification.applications.trace\\.easyOne\\.communicator\\.windows.name"
+                ]
+            }
+        ],
+        "lifecycleManager" : {
+            "start": [
+                {
+                    "type": "gpii.launch.exec",
+                    "command": "\"${{environment}.PROGRAMFILES(x86)}\\Mozilla Firefox\\firefox.exe\" http://easy1234.org/user/${{userToken}}"
+                }
+            ],
+            "stop": [
+                {
+                    "type": "gpii.launch.exec",
+                    "command": "${{environment}.SystemRoot}\\System32\\taskkill.exe /im firefox.exe"
+                }
+            ]
+        }
+    },
+    
+    {
+        "name": "EasyOne Communicator Linux",
+        "id": "trace.easyOne.communicator.linux",
+        "contexts": {
+            "OS": [
+                {
+                    "id": "linux",
+                    "version": ">=2.6.26"
+                }
+            ]
+        },
+        "settingsHandlers": [
+            {
+                "type": "gpii.settingsHandlers.noSettings",
+                "capabilities": [
+                    "content.simplification",
+                    "content.simplification.applications.trace\\.easyOne\\.communicator\\.linux.name"
+                ]
+            }
+        ],
+        "lifecycleManager" : {
+            "start": [
+                {
+                    "type": "gpii.launch.exec",
+                    "command": "google-chrome http://easy1234.org/user/${{userToken}}"
+                }
+            ],
+            "stop": [
+                {
+                    "type": "gpii.launch.exec",
+                    "command": "pkill -2 chrome"
+                }
+            ]
+        }
+    },
+    
+    {
+        "name": "EasyOne Communicator Sudan",
+        "id": "trace.easyOne.sudan.windows",
+        "contexts": {
+            "OS": [
+                {
+                    "id": "win32",
+                    "version": ">=5.0"
+                }
+            ]
+        },
+        "settingsHandlers": [
+            {
+                "type": "gpii.settingsHandlers.noSettings",
+                "capabilities": [
+                    "content.pictorialSimplification",
+                    "content.pictorialSimplification.applications.trace\\.easyOne\\.sudan\\.windows.name"
+                ]
+            }
+        ],
+        "lifecycleManager" : {
+            "start": [
+                {
+                    "type": "gpii.launch.exec",
+                    "command": "\"${{environment}.PROGRAMFILES(x86)}\\Mozilla Firefox\\firefox.exe\" http://easy1234.org/sudan"
+                }
+            ],
+            "stop": [
+                {
+                    "type": "gpii.launch.exec",
+                    "command": "${{environment}.SystemRoot}\\System32\\taskkill.exe /im firefox.exe"
+                }
+            ]
+        }
+    },
+    
+    {
+        "name": "EasyOne Communicator Sudan",
+        "id": "trace.easyOne.sudan.linux",
+        "contexts": {
+            "OS": [
+                {
+                    "id": "linux",
+                    "version": ">=2.6.26"
+                }
+            ]
+        },
+        "settingsHandlers": [
+            {
+                "type": "gpii.settingsHandlers.noSettings",
+                "capabilities": [
+                    "content.pictorialSimplification",
+                    "content.pictorialSimplification.applications.trace\\.easyOne\\.sudan\\.linux.name"
+                ]
+            }
+        ],
+        "lifecycleManager" : {
+            "start": [
+                {
+                    "type": "gpii.launch.exec",
+                    "command": "google-chrome http://easy1234.org/sudan"
+                }
+            ],
+            "stop": [
+                {
+                    "type": "gpii.launch.exec",
+                    "command": "pkill -2 chrome"
+                }
+            ]
+        }
+    },
+    
+    {
+        "name": "Web Anywhere",
+        "id": "webinsight.webAnywhere.windows",
+        "contexts": {
+            "OS": [
+                {
+                    "id": "win32",
+                    "version": ">=5.0"
+                }
+            ]
+        },
+        "settingsHandlers": [
+            {
+                "type": "gpii.settingsHandlers.noSettings",
+                "capabilities": [
+                    "display.screenReader",
+                    "display.screenReader.applications.webinsight\\.webAnywhere\\.windows.name"
+                ]
+            }
+        ],
+        "lifecycleManager" : {
+             "start": [
+                {
+                    "type": "gpii.launch.exec",
+                    "command": "\"${{environment}.PROGRAMFILES(x86)}\\Mozilla Firefox\\firefox.exe\" \"http://webanywhere.cs.washington.edu/beta/?starting_url=http://ec2-107-21-143-113.compute-1.amazonaws.com:443/demos/Mammals.html?token=${{userToken}}\""
+                }
+            ],
+            "stop": [
+                {
+                    "type": "gpii.launch.exec",
+                    "command": "${{environment}.SystemRoot}\\System32\\taskkill.exe /im firefox.exe"
+                }
+            ]
+        }
+    },
+    
+    {
+        "name": "Web Anywhere",
+        "id": "webinsight.webAnywhere.linux",
+        "contexts": {
+            "OS": [
+                {
+                    "id": "linux",
+                    "version": ">=2.6.26"
+                }
+            ]
+        },
+        "settingsHandlers": [
+            {
+                "type": "gpii.settingsHandlers.noSettings",
+                "capabilities": [
+                    "display.screenReader",
+                    "display.screenReader.applications.webinsight\\.webAnywhere\\.linux.name"
+                ]
+            }
+        ],
+        "lifecycleManager" : {
+            "start": [
+                {
+                    "type": "gpii.launch.exec",
+                    "command": "google-chrome http://webanywhere.cs.washington.edu/beta/?starting_url=http://ec2-107-21-143-113.compute-1.amazonaws.com:443/demos/Mammals.html?token=${{userToken}}"
+                }
+            ],
+            "stop": [
+                {
+                    "type": "gpii.launch.exec",
+                    "command": "pkill -2 chrome"
                 }
             ]
         }

--- a/gpii/node_modules/flowManager/test/data/user.profile.123.json
+++ b/gpii/node_modules/flowManager/test/data/user.profile.123.json
@@ -5,24 +5,25 @@
             "tracking": "mouse",
 
             "screenMagnification": {
-                "applications": [{
-                    "name": "GNOME Shell Magnifier",
-                    "id": "org.gnome.desktop.a11y.magnifier",
-                    "priority": 100,
-                    "parameters": {
-                        "show-cross-hairs": true
-                    }
-                }, {
-                    "name": "Windows Magnifier",
-                    "id": "com.microsoft.windows.magnifier",
-                    "priority": 0,
-                    "parameters": {
-                        "MagnifierUIWindowMinimized": {
-                            "value": 0,
-                            "dataType": "REG_DWORD"
+                "applications": {
+                    "org.gnome.desktop.a11y.magnifier": {
+                        "name": "GNOME Shell Magnifier",
+                        "priority": 100,
+                        "parameters": {
+                            "show-cross-hairs": true
+                        }
+                    },
+                    "com.microsoft.windows.magnifier": {
+                        "name": "Windows Magnifier",
+                        "priority": 0,
+                        "parameters": {
+                            "MagnifierUIWindowMinimized": {
+                                "value": 0,
+                                "dataType": "REG_DWORD"
+                            }
                         }
                     }
-                }]
+                }
             }
         }
     }

--- a/gpii/node_modules/flowManager/test/data/user.profile.carla.json
+++ b/gpii/node_modules/flowManager/test/data/user.profile.carla.json
@@ -46,6 +46,7 @@
                 ],
                 "genericFontFace": "sans serif"
             },
+            
             "screenMagnification": {
                 "applications": {
                     "org.gnome.desktop.a11y.magnifier": {

--- a/gpii/node_modules/flowManager/test/data/user.profile.elaine.json
+++ b/gpii/node_modules/flowManager/test/data/user.profile.elaine.json
@@ -1,15 +1,16 @@
 {
     "content": {
         "simplification": {
-            "applications": [{
-                "name": "EasyOne Communicator",
-                "id": "trace.easyOne.communicator.windows",
-                "priority": 100
-            }, {
-                "name": "EasyOne Communicator",
-                "id": "trace.easyOne.communicator.linux",
-                "priority": 100
-            }]
+            "applications": {
+                "trace.easyOne.communicator.windows": {
+                    "name": "EasyOne Communicator",
+                    "priority": 100
+                },
+                "trace.easyOne.communicator.linux": {
+                    "name": "EasyOne Communicator",
+                    "priority": 100
+                }
+            }
         }
     }
 }

--- a/gpii/node_modules/flowManager/test/data/user.profile.nisha.json
+++ b/gpii/node_modules/flowManager/test/data/user.profile.nisha.json
@@ -61,7 +61,7 @@
     "control": {
         "onscreenKeyboard": {
             "applications": {
-                "org.gnome.desktop.a11y.keyboard": {
+                "org.gnome.desktop.a11y.caribou-keyboard": {
                     "name": "GNOME Shell On Screen Keyboard",
                     "priority": 100
                 },

--- a/gpii/node_modules/flowManager/test/data/user.profile.omar.json
+++ b/gpii/node_modules/flowManager/test/data/user.profile.omar.json
@@ -1,15 +1,16 @@
 {
     "content": {
         "pictorialSimplification": {
-            "applications": [{
-                "name": "EasyOne Communicator Sudan Windows",
-                "id": "trace.easyOne.sudan.windows",
-                "priority": 100
-            }, {
-                "name": "EasyOne Communicator Sudan Linux",
-                "id": "trace.easyOne.sudan.linux",
-                "priority": 100
-            }]
+            "applications": {
+                "trace.easyOne.sudan.windows": {
+                    "name": "EasyOne Communicator Sudan Windows",
+                    "priority": 100
+                },
+                "trace.easyOne.sudan.linux": {
+                    "name": "EasyOne Communicator Sudan Linux",
+                    "priority": 100
+                }
+            }
         }
     }
 }

--- a/gpii/node_modules/flowManager/test/data/user.profile.sammy.json
+++ b/gpii/node_modules/flowManager/test/data/user.profile.sammy.json
@@ -1,7 +1,7 @@
 {
     "display": {
         "screenEnhancement": {
-        	"fontSize": 24,
+            "fontSize": 24,
             "foregroundColor": "white",
             "backgroundColor": "black",
             "fontFace": {

--- a/gpii/node_modules/flowManager/test/data/user.profile.timothy.json
+++ b/gpii/node_modules/flowManager/test/data/user.profile.timothy.json
@@ -1,31 +1,32 @@
 {
     "languageAssistance": {
-        "applications": [{
-            "name": "Read Write Gold",
-            "id": "com.texthelp.readWriteGold",
-            "priority": 100,
-            "parameters": {
-                "ApplicationSettings.AppBar.Width.$t": 1072,
-                "ApplicationSettings.AppBar.ShowText.$t": true,
-                "ApplicationSettings.AppBar.optToolbarShowText.$t": true,
-                "ApplicationSettings.AppBar.LargeIcons.$t": true,
-                "ApplicationSettings.AppBar.optToolbarLargeIcons.$t": true,
-                "ApplicationSettings.Speech.optSAPI5Speed.$t": 50,
-                "ApplicationSettings.Speech.optAutoUseScreenReading.$t": false
+        "applications": {
+            "com.texthelp.readWriteGold": {
+                "name": "Read Write Gold",
+                "priority": 100,
+                "parameters": {
+                    "ApplicationSettings.AppBar.Width.$t": 1072,
+                    "ApplicationSettings.AppBar.ShowText.$t": true,
+                    "ApplicationSettings.AppBar.optToolbarShowText.$t": true,
+                    "ApplicationSettings.AppBar.LargeIcons.$t": true,
+                    "ApplicationSettings.AppBar.optToolbarLargeIcons.$t": true,
+                    "ApplicationSettings.Speech.optSAPI5Speed.$t": 50,
+                    "ApplicationSettings.Speech.optAutoUseScreenReading.$t": false
+                }
             }
-        }]
+        }
     },
+    
     "display": {
-    	"applications": [
-            {
-                "name": "UI Options",
-                "id": "fluid.uiOptions.windows"
-            }, {
-                "name": "UI Options",
-                "id": "fluid.uiOptions.linux"
-            }, {
+    	"applications": {
+        	"fluid.uiOptions.windows": {
+                "name": "UI Options"
+            },
+            "fluid.uiOptions.linux": {
+                "name": "UI Options"
+            },
+            "fluid.uiOptions": {
             	"name": "UI Options",
-                "id": "fluid.uiOptions",
                 "parameters": {
                     "lineSpacing": "1.5",
                     "links": true,
@@ -35,7 +36,8 @@
                     "volume": "50"
                 }
            	}
-        ],
+    	},
+    	
         "screenEnhancement": {
         	"fontSize": 18,
             "foregroundColor": "white",
@@ -46,21 +48,22 @@
                 ],
                 "genericFontFace": "sans serif"
             },
-            "applications": [{
-                "name": "GNOME Interface Settings",
-                "id": "org.gnome.desktop.interface",
-                "priority": 100,
-                "parameters": {
-                    "text-scaling-factor": 1.6
+            "applications": {
+                "org.gnome.desktop.interface": {
+                    "name": "GNOME Interface Settings",
+                    "priority": 100,
+                    "parameters": {
+                        "text-scaling-factor": 1.6
+                    }
+                },
+                "org.gnome.nautilus": {
+                    "name": "GNOME Nautilus Desktop Settings",
+                    "priority": 100,
+                    "parameters": {
+                        "font": "Cantarell 18"
+                    }
                 }
-            }, {
-                "name": "GNOME Nautilus Desktop Settings",
-                "id": "org.gnome.nautilus",
-                "priority": 100,
-                "parameters": {
-                    "font": "Cantarell 18"
-                }
-            }]
+            }
         }
     },
     "control": {


### PR DESCRIPTION
Also reinstates the web-based solutions into the registry and adds a new example preferences payload.

I've tested this on both Windows and Linux. Can someone do a quick review? This is the tip of an iceberg which will culminate in a complete reorganization and normalization of our preferences and device reporter documents for demos, examples, etc.
