### PR TITLE
GPII-43: Updates the example preference document to the new flat style.

### DIFF
--- a/examples/preferences/accessforall-with-application-specific.json
+++ b/examples/preferences/accessforall-with-application-specific.json
@@ -1,23 +1,23 @@
 {
-    "http://registry.gpii.net/core/fontSize": [
+    "http://registry.gpii.net/common/fontSize": [
         {
             "value": 24
         }
     ],
     
-    "http://registry.gpii.net/core/magnification": [
+    "http://registry.gpii.net/common/magnification": [
         {
             "value": 2.0
         }
     ],
     
-    "http://registry.gpii.net/core/tracking": [
+    "http://registry.gpii.net/common/tracking": [
         {
             "value": "mouse"
         }
     ],
     
-    "http://registry.gpii.net/core/invertImages": [
+    "http://registry.gpii.net/common/invertImages": [
         {
             "value": true
         }
@@ -29,7 +29,7 @@
         }
     ],
     
-    "http://registry.gpii.net/core/stickyKeys": [
+    "http://registry.gpii.net/common/stickyKeys": [
         {
             "value": true
         }


### PR DESCRIPTION
This contains a quick update to the example preference document we link to in the GPII wiki in order to flatten it. Since we don't yet have the registry with a list of common and core terms, I'm not convinced that my URLs are quite right, but they should be illustrative at least of the intended format.
