### PR TITLE
GPII-61: Fixed bug where flowmanager would overwrite settings given in the config of makeConfigLoader

### DIFF
--- a/gpii/node_modules/flowManager/configs/development.json
+++ b/gpii/node_modules/flowManager/configs/development.json
@@ -9,35 +9,6 @@
                     "logging": true,
                     "port": 8081,
                     "components": {
-                        "deviceReporter": {
-                            "type": "gpii.deviceReporter",
-                            "options": {
-                                "typeName": "deviceReporter.development",
-                                "installedSolutionsUrl": "file://%root/../../../testData/deviceReporter/installedSolutions.json"
-                            }
-                        },
-                        "preferencesServer": {
-                            "type": "gpii.preferencesServer",
-                            "options": {
-                                "typeName": "preferencesServer.development",
-                                "userSourceUrl": "file://%root/../../../testData/preferences/%token.json"
-                            }
-                        },
-                        "matchMaker": {
-                            "type": "gpii.matchMaker",
-                            "options": {
-                                "typeName": "matchMaker.development",
-                                "solutionsReporterUrl": "http://localhost:%port/solution?os=%os&version=%version"
-                            }
-                        },
-                        "solutionsRegistry": {
-                            "type": "gpii.solutionsRegistry",
-                            "options": {
-                                "typeName": "solutionsRegistry.development",
-                                "solutionRegistryUrl": "file://%root/../../../testData/solutions/%id.json",
-                                "solutionQueryUrl": "file://%root/../../../testData/solutions/%os.json"
-                            }
-                        },
                         "flowManager": {
                             "type": "gpii.flowManager",
                             "options": {

--- a/gpii/node_modules/flowManager/configs/production.json
+++ b/gpii/node_modules/flowManager/configs/production.json
@@ -9,37 +9,8 @@
                     "logging": false,
                     "port": 8081,
                     "components": {
-                        "deviceReporter": {
-                            "type": "gpii.deviceReporter",
-                            "options": {
-                                "typeName": "deviceReporter.production",
-                                "installedSolutionsUrl": "file://%root/../../../testData/deviceReporter/installedSolutions.json"
-                            }
-                        },
-                        "preferencesServer": {
-                            "type": "gpii.preferencesServer",
-                            "options": {
-                                "typeName": "preferencesServer.production",
-                                "userSourceUrl": "http://localhost:5984/user/%token"
-                            }
-                        },
-                        "matchMaker": {
-                            "type": "gpii.matchMaker",
-                            "options": {
-                                "typeName": "matchMaker.production",
-                                "solutionsReporterUrl": "http://localhost:%port/solution?os=%os&version=%version"
-                            }
-                        },
-                        "solutionsRegistry": {
-                            "type": "gpii.solutionsRegistry",
-                            "options": {
-                                "typeName": "solutionsRegistry.production",
-                                "solutionRegistryUrl": "http://localhost:5984/gpii-sol-registry/_design/gpii-solutions/_rewrite/solutions/%id",
-                                "solutionQueryUrl": "http://localhost:5984/gpii-sol-registry/_design/gpii-solutions/_rewrite/solutions?os=%os"
-                            }
-                        },
                         "flowManager": {
-                            "type": "gpii.flowManager"
+                            "type": "gpii.flowManager",
                             "options": {
                                 "typeName": "flowManager.production",
                                 "urls": {


### PR DESCRIPTION
Removed default settings of other components from flowmanager in development and production config.
