### PR TITLE
Modification of the user preferences files for the pilot testing of the Easit4all. 

### DIFF
--- a/testData/preferences/test1.json
+++ b/testData/preferences/test1.json
@@ -1,69 +1,15 @@
 {
-    "http://registry.gpii.org/common/fontSize": [
-        {
-            "value": 11
-        }
-    ],
-    "http://registry.gpii.org/common/foregroundColor": [
-        {
-            "value": "yellow"
-        }
-    ],
-    "http://registry.gpii.org/common/backgroundColor": [
-        {
-            "value": "black"
-        }
-    ],
-    "http://registry.gpii.org/common/fontFaceFontName": [
-        {
-            "value": [
-                "ARIAL"
-            ]
-        }
-    ],
-    "http://registry.gpii.org/common/fontFaceGenericFontFace": [
-        {
-            "value": "SERIF"
-        }
-    ],
-    "http://registry.gpii.org/common/magnification": [
-        {
-            "value": 1
-        }
-    ],
-    "http://registry.gpii.org/common/tracking": [
-        {
-            "value": "mouse"
-        }
-    ],
-    "http://registry.gpii.org/common/invertImages": [
-        {
-            "value": false
-        }
-    ],
-    "http://registry.gpii.org/common/links": [
-        {
-            "value": true
-        }
-    ],
-    "http://registry.gpii.org/common/toc": [
-        {
-            "value": false
-        }
-    ],
-    "http://registry.gpii.org/common/inputsLarger": [
-        {
-            "value": true
-        }
-    ],
-    "http://registry.gpii.org/common/layout": [
-        {
-            "value": false
-        }
-    ],
-    "http://registry.gpii.org/common/lineSpacing": [
-        {
-            "value": 1.2
-        }
-    ]
+    "http://registry.gpii.org/common/fontSize": [{ "value": 11 }],
+    "http://registry.gpii.org/common/foregroundColor": [{ "value": "yellow" }],
+    "http://registry.gpii.org/common/backgroundColor": [{ "value": "black" }],
+    "http://registry.gpii.org/common/fontFaceFontName": [{ "value": [ "ARIAL" ] }],
+    "http://registry.gpii.org/common/fontFaceGenericFontFace": [{ "value": "SERIF" }],
+    "http://registry.gpii.org/common/magnification": [{ "value": 1 }],
+    "http://registry.gpii.org/common/tracking": [{ "value": "mouse" }],
+    "http://registry.gpii.org/common/invertImages": [{ "value": false }],
+    "http://registry.gpii.org/common/links": [{ "value": true }],
+    "http://registry.gpii.org/common/toc": [{ "value": false }],
+    "http://registry.gpii.org/common/inputsLarger": [{ "value": true }],
+    "http://registry.gpii.org/common/layout": [{ "value": false }],
+    "http://registry.gpii.org/common/lineSpacing": [{ "value": 1.2 }]
 }

--- a/testData/preferences/test2.json
+++ b/testData/preferences/test2.json
@@ -1,69 +1,15 @@
 {
-    "http://registry.gpii.org/common/fontSize": [
-        {
-            "value": 10
-        }
-    ],
-    "http://registry.gpii.org/common/foregroundColor": [
-        {
-            "value": "default"
-        }
-    ],
-    "http://registry.gpii.org/common/backgroundColor": [
-        {
-            "value": "default"
-        }
-    ],
-    "http://registry.gpii.org/common/fontFaceFontName": [
-        {
-            "value": [
-                "default"
-            ]
-        }
-    ],
-    "http://registry.gpii.org/common/fontFaceGenericFontFace": [
-        {
-            "value": "default"
-        }
-    ],
-    "http://registry.gpii.org/common/magnification": [
-        {
-            "value": 1
-        }
-    ],
-    "http://registry.gpii.org/common/tracking": [
-        {
-            "value": "mouse"
-        }
-    ],
-    "http://registry.gpii.org/common/invertImages": [
-        {
-            "value": false
-        }
-    ],
-    "http://registry.gpii.org/common/links": [
-        {
-            "value": false
-        }
-    ],
-    "http://registry.gpii.org/common/toc": [
-        {
-            "value": false
-        }
-    ],
-    "http://registry.gpii.org/common/inputsLarger": [
-        {
-            "value": false
-        }
-    ],
-    "http://registry.gpii.org/common/layout": [
-        {
-            "value": false
-        }
-    ],
-    "http://registry.gpii.org/common/lineSpacing": [
-        {
-            "value": 1
-        }
-    ]
+    "http://registry.gpii.org/common/fontSize": [{ "value": 10 }],
+    "http://registry.gpii.org/common/foregroundColor": [{ "value": "default" }],
+    "http://registry.gpii.org/common/backgroundColor": [{ "value": "default" }],
+    "http://registry.gpii.org/common/fontFaceFontName": [{ "value": [ "default" ] }],
+    "http://registry.gpii.org/common/fontFaceGenericFontFace": [{ "value": "default" }],
+    "http://registry.gpii.org/common/magnification": [{ "value": 1 }],
+    "http://registry.gpii.org/common/tracking": [{ "value": "mouse" }],
+    "http://registry.gpii.org/common/invertImages": [{ "value": false }],
+    "http://registry.gpii.org/common/links": [{ "value": false }],
+    "http://registry.gpii.org/common/toc": [{ "value": false }],
+    "http://registry.gpii.org/common/inputsLarger": [{ "value": false }],
+    "http://registry.gpii.org/common/layout": [{ "value": false }],
+    "http://registry.gpii.org/common/lineSpacing": [{ "value": 1 }]
 }


### PR DESCRIPTION
Now, the user preferences contained in these files have the appropiated format to work with the recently updated remote preferences server (http://preferences.gpii.net/user/). 

Names of the both files are not changed to avoid changes in the pilot testing. After the pilots, these names will be renamed to e.g. easit-test1, easit-test2
