### PR TITLE
Adding 'es-ES' as a valid auditoryOutLanguage common term

### DIFF
--- a/testData/solutions/linux.json
+++ b/testData/solutions/linux.json
@@ -725,6 +725,17 @@
                                         }
                                     }
                                 },
+                                "es-ES": {
+                                    "outputValue": {
+                                        "expander" : {
+                                            "type": "fluid.model.transform.literalValue",
+                                            "value": {
+                                                "locale": "es",
+                                                "name": "spanish"
+                                            }
+                                        }
+                                    }
+                                },
                                 "es-419": {
                                     "outputValue": {
                                         "expander" : {


### PR DESCRIPTION
The lnux solution was missing the 'es-ES' as a valid value for the auditoryOutLanguage common term.

Cheers,
Javi
