### PR TITLE
GPII-156: Adding common and cross-platform getJSONFromFile method to gpii.utils

### DIFF
--- a/gpii/node_modules/gpiiFramework/utils.js
+++ b/gpii/node_modules/gpiiFramework/utils.js
@@ -97,7 +97,7 @@ https://github.com/gpii/universal/LICENSE.txt
         };
     };
 
-    gpii.getJSONFromFile = function (filePath) {
+    gpii.getJSONFromFileSync = function (filePath) {
         return JSON.parse(fs.readFileSync(filePath, "utf8"));
     };
 


### PR DESCRIPTION
Adding common and cross-platform getJSONFromFile method to gpii.utils.

Just a question, do you want me to use the async version of fs.readFile before merging this into master?

Cheers,
Javi
