### PR TITLE
GPII-161: Add support for some specific GNOME solutions

### DIFF
--- a/testData/deviceReporter/installedSolutions.json
+++ b/testData/deviceReporter/installedSolutions.json
@@ -2,6 +2,14 @@
     {
         "id": "org.gnome.desktop.interface"
     },
+
+    {
+        "id": "org.gnome.shell.overrides"
+    },
+
+    {
+        "id": "org.gnome.desktop.wm.preferences"
+    },
     
     {
         "id": "org.gnome.nautilus"

--- a/testData/deviceReporter/linux_installedSolutions.json
+++ b/testData/deviceReporter/linux_installedSolutions.json
@@ -29,6 +29,14 @@
         },
         
         {
+            "id": "org.gnome.shell.overrides"
+        },
+
+        {
+            "id": "org.gnome.desktop.wm.preferences"
+        },
+
+        {
             "id": "com.microsoft.windows.magnifier"
         },
         

--- a/testData/solutions/linux.json
+++ b/testData/solutions/linux.json
@@ -270,6 +270,64 @@
     },
 
     {
+        "name": "GNOME desktop Window Manager preferences",
+        "id": "org.gnome.desktop.wm.preferences",
+        "contexts": {
+            "OS": [{
+                "id": "linux",
+                "version": ">=2.6.26"
+            }]
+        },
+
+        "settingsHandlers": [
+            {
+                "type": "gpii.gsettings.set",
+                "capabilities": [
+                    "applications.org\\.gnome\\.desktop\\.wm\\.preferences.id",
+                    "display.screenEnhancement.applications.org\\.gnome\\.desktop\\.wm\\.preferences.name"
+                ],
+                "options": {
+                    "schema": "org.gnome.desktop.wm.preferences"
+                }
+            }
+        ],
+
+        "lifecycleManager": {
+            "start": [ "setSettings" ],
+            "stop": [ "restoreSettings" ]
+        }
+    },
+
+    {
+        "name": "GNOME Shell overrides",
+        "id": "org.gnome.shell.overrides",
+        "contexts": {
+            "OS": [{
+                "id": "linux",
+                "version": ">=2.6.26"
+            }]
+        },
+
+        "settingsHandlers": [
+            {
+                "type": "gpii.gsettings.set",
+                "capabilities": [
+                    "applications.org\\.gnome\\.shell\\.overrides.id",
+                    "display.screenEnhancement.applications.org\\.gnome\\.shell\\.overrides.name"
+                ],
+                "options": {
+                    "schema": "org.gnome.shell.overrides"
+                }
+            }
+        ],
+
+        "lifecycleManager": {
+            "start": [ "setSettings" ],
+            "stop": [ "restoreSettings" ]
+        }
+    },
+
+    {
         "name": "ORCA Screen Reader",
         "id": "org.gnome.orca",
         "contexts": {


### PR DESCRIPTION
This patch includes the support to deal with these following gsettings
schemas:
- org.gnome.shell.overrides
- org.gnome.desktop.wm.preferences
- This pull request deprecates https://github.com/GPII/universal/pull/74

Cheers,
Javi
