### PR TITLE
GPII-251: Updated all entries of invertImages to invertColours

### DIFF
--- a/examples/preferences/accessforall-with-application-specific.json
+++ b/examples/preferences/accessforall-with-application-specific.json
@@ -17,7 +17,7 @@
         }
     ],
 
-    "http://registry.gpii.net/common/invertImages": [
+    "http://registry.gpii.net/common/invertColours": [
         {
             "value": true
         }

--- a/gpii/node_modules/matchMaker/src/inverseRules.json
+++ b/gpii/node_modules/matchMaker/src/inverseRules.json
@@ -23,7 +23,7 @@
         ]
     },
     "com.microsoft.windows.magnifier": {
-        "display.screenEnhancement.invertImages": "Invert.value",
+        "display.screenEnhancement.-provisional-invertColours": "Invert.value",
         "transform": [
             {
                 "type": "fluid.transforms.linearScale",

--- a/gpii/node_modules/matchMaker/test/js/AsynchronousMatchMakerTest.js
+++ b/gpii/node_modules/matchMaker/test/js/AsynchronousMatchMakerTest.js
@@ -54,7 +54,7 @@ var gpii = fluid.registerNamespace("gpii");
                 },
                 "magnification": 2.0,
                 "tracking": ["mouse"],
-                "invertImages": true,
+                "-provisional-invertColours": true,
                 "-provisional-showCrosshairs": true
             }
         }

--- a/gpii/node_modules/matchMaker/test/js/CanopyMatchMakerTests.js
+++ b/gpii/node_modules/matchMaker/test/js/CanopyMatchMakerTests.js
@@ -97,20 +97,20 @@ var gpii = fluid.registerNamespace("gpii");
                 },
                 "magnification": 2.0,
                 "tracking": ["mouse"],
-                "invertImages": true,
+                "-provisional-invertColours": true,
                 "-provisional-showCrosshairs": true
             }
         }
     };
 
     var sammyLeaves = [
+        "display.screenEnhancement.-provisional-invertColours",
         "display.screenEnhancement.-provisional-showCrosshairs",
         "display.screenEnhancement.backgroundColor",
         "display.screenEnhancement.fontFace.fontName.0",
         "display.screenEnhancement.fontFace.genericFontFace",
         "display.screenEnhancement.fontSize",
         "display.screenEnhancement.foregroundColor",
-        "display.screenEnhancement.invertImages",
         "display.screenEnhancement.magnification",
         "display.screenEnhancement.tracking.0"
     ];

--- a/gpii/node_modules/matchMaker/test/js/FlatMatchMakerTests.js
+++ b/gpii/node_modules/matchMaker/test/js/FlatMatchMakerTests.js
@@ -63,7 +63,7 @@ var gpii = fluid.registerNamespace("gpii");
                 },
                 "magnification": 2.0,
                 "tracking": ["mouse"],
-                "invertImages": true,
+                "-provisional-invertColours": true,
                 "-provisional-showCrosshairs": true
             }
         }

--- a/gpii/node_modules/ontologyServer/test/js/OntologyServerTests.js
+++ b/gpii/node_modules/ontologyServer/test/js/OntologyServerTests.js
@@ -25,7 +25,7 @@ var gpii = fluid.registerNamespace("gpii");
         "flat": {
             "http://registry.gpii.org/common/magnification": [{value: 2.0}],
             "http://registry.gpii.org/common/tracking": [{value: ["mouse"]}],
-            "http://registry.gpii.org/common/invertImages": [{value: true}],
+            "http://registry.gpii.org/common/invertColours": [{value: true}],
             "http://registry.gpii.org/applications/some.application.id": [{
                 "value": {
                     "some setting": true
@@ -43,7 +43,7 @@ var gpii = fluid.registerNamespace("gpii");
         "ISO24751-2/flat": {
             "display.screenEnhancement.fontSize": "{http://registry.gpii.org/common/fontSize}.0.value",
             "display.screenEnhancement.tracking": "{http://registry.gpii.org/common/tracking}.0.value",
-            "display.screenEnhancement.invertImages": "{http://registry.gpii.org/common/invertImages}.0.value",
+            "display.screenEnhancement.-provisional-invertColours": "{http://registry.gpii.org/common/invertColours}.0.value",
             "": {
                 "transform": {
                     "type": "gpii.ontologyServer.transform.application",
@@ -77,7 +77,7 @@ var gpii = fluid.registerNamespace("gpii");
                 "ISO24751-2/flat": {
                     "display.screenEnhancement.fontSize": "http://registry\\.gpii\\.org/common/fontSize.0.value",
                     "display.screenEnhancement.tracking": "http://registry\\.gpii\\.org/common/tracking.0.value",
-                    "display.screenEnhancement.invertImages": "http://registry\\.gpii\\.org/common/invertImages.0.value",
+                    "display.screenEnhancement.-provisional-invertColours": "http://registry\\.gpii\\.org/common/invertColours.0.value",
                     "": {
                         "transform": {
                             "type": "gpii.ontologyServer.transform.application",
@@ -96,7 +96,7 @@ var gpii = fluid.registerNamespace("gpii");
             var transformations = {
                 "display.screenEnhancement.magnification": "http://registry\\.gpii\\.org/common/magnification.0.value",
                 "display.screenEnhancement.tracking": "http://registry\\.gpii\\.org/common/tracking.0.value",
-                "display.screenEnhancement.invertImages": "http://registry\\.gpii\\.org/common/invertImages.0.value",
+                "display.screenEnhancement.-provisional-invertColours": "http://registry\\.gpii\\.org/common/invertColours.0.value",
                 "": {
                     "transform": {
                         "type": "gpii.ontologyServer.transform.application",
@@ -124,7 +124,7 @@ var gpii = fluid.registerNamespace("gpii");
                     screenEnhancement: {
                         magnification: 2.0,
                         tracking: ["mouse"],
-                        invertImages: true
+                        "-provisional-invertColours": true
                     }
                 }
             }, fluid.model.transformWithRules(preferences["flat"], transformations));

--- a/testData/ontologies/ISO24751-2/flat.json
+++ b/testData/ontologies/ISO24751-2/flat.json
@@ -9,7 +9,7 @@
         "display.screenEnhancement.-provisional-magnifierPosition": "{http://registry.gpii.org/common/magnifierPosition}.0.value",
         "display.screenEnhancement.tracking": "{http://registry.gpii.org/common/tracking}.0.value",
         "display.screenEnhancement.trackingTTS": "{http://registry.gpii.org/common/trackingTTS}.0.value",
-        "display.screenEnhancement.invertImages": "{http://registry.gpii.org/common/invertImages}.0.value",
+        "display.screenEnhancement.-provisional-invertColours": "{http://registry.gpii.org/common/invertColours}.0.value",
         "display.screenEnhancement.cursorSize": "{http://registry.gpii.org/common/cursorSize}.0.value",
         "display.screenEnhancement.highContrast": "{http://registry.gpii.org/common/highContrast}.0.value",
         "display.screenEnhancement.mouseTrailing": "{http://registry.gpii.org/common/mouseTrailing}.0.value",
@@ -26,7 +26,7 @@
         "display.screenReader.-provisional-screenReaderTTSEnabled": "{http://registry.gpii.org/common/screenReaderTTSEnabled}.0.value",
 
         "display.textReadingHighlight.readingUnit": "{http://registry.gpii.org/common/readingUnit}.0.value",
-        
+
         "display.braille.-provisional-brailleMode": "{http://registry.gpii.org/common/brailleMode}.0.value",
 
         "control.onscreenKeyboard": "{http://registry.gpii.org/common/onscreenKeyboard}.0.value",
@@ -35,14 +35,14 @@
         "control.mouseEmulation.cursorAcceleration": "{http://registry.gpii.org/common/cursorAcceleration}.0.value",
         "control.mouseEmulation.-provisional-mouseEmulationEnabled": "{http://registry.gpii.org/common/-provisional-mouseEmulationEnabled}.0.value",
         "control.keyboardEnhancement.stickyKeys": "{http://registry.gpii.org/common/stickyKeys}.0.value",
-        "control.keyboardEnhancement.slowKeys.slowKeysInterval": "{http://registry.gpii.org/common/slowKeysInterval}.0.value",          
+        "control.keyboardEnhancement.slowKeys.slowKeysInterval": "{http://registry.gpii.org/common/slowKeysInterval}.0.value",
         "control.keyboardEnhancement.slowKeys.-provisional-slowKeysEnable": "{http://registry.gpii.org/common/-provisional-slowKeysEnable}.0.value",
         "control.keyboardEnhancement.debounceKeys.-provisional-debounceEnable": "{http://registry.gpii.org/common/-provisional-debounceEnable}.0.value",
         "control.keyboardEnhancement.debounceKeys.debounceInterval": "{http://registry.gpii.org/common/debounceInterval}.0.value",
 
         "content.adaptationPreference": "{http://registry.gpii.org/common/adaptationPreference}.0.value",
         "control.structuralNavigation.tableOfContents": "{http://registry.gpii.org/common/tableOfContents}.0.value",
-        
+
         "": {
             "transform": {
                 "type": "gpii.ontologyServer.transform.application",

--- a/testData/ontologies/ontologies.json
+++ b/testData/ontologies/ontologies.json
@@ -10,7 +10,7 @@
             "display.screenEnhancement.-provisional-magnifierPosition": "{http://registry.gpii.org/common/magnifierPosition}.0.value",
             "display.screenEnhancement.tracking": "{http://registry.gpii.org/common/tracking}.0.value",
             "display.screenEnhancement.trackingTTS": "{http://registry.gpii.org/common/trackingTTS}.0.value",
-            "display.screenEnhancement.invertImages": "{http://registry.gpii.org/common/invertImages}.0.value",
+            "display.screenEnhancement.-provisional-invertColours": "{http://registry.gpii.org/common/invertColours}.0.value",
             "display.screenEnhancement.cursorSize": "{http://registry.gpii.org/common/cursorSize}.0.value",
             "display.screenEnhancement.highContrast": "{http://registry.gpii.org/common/highContrast}.0.value",
             "display.screenEnhancement.mouseTrailing": "{http://registry.gpii.org/common/mouseTrailing}.0.value",
@@ -27,7 +27,7 @@
             "display.screenReader.-provisional-screenReaderTTSEnabled": "{http://registry.gpii.org/common/screenReaderTTSEnabled}.0.value",
 
             "display.textReadingHighlight.readingUnit": "{http://registry.gpii.org/common/readingUnit}.0.value",
-            
+
             "display.braille.-provisional-brailleMode": "{http://registry.gpii.org/common/brailleMode}.0.value",
 
             "control.onscreenKeyboard": "{http://registry.gpii.org/common/onscreenKeyboard}.0.value",

--- a/testData/preferences/carla.json
+++ b/testData/preferences/carla.json
@@ -12,7 +12,7 @@
     }],
     "http://registry.gpii.org/applications/fluid.uiOptions.windows": [{ "value": {}}],
     "http://registry.gpii.org/applications/fluid.uiOptions.linux": [{ "value": {}}],
-    "http://registry.gpii.org/applications/fluid.uiOptions": [{ 
+    "http://registry.gpii.org/applications/fluid.uiOptions": [{
         "value": {
             "lineSpacing": "2",
             "links": true,
@@ -22,7 +22,7 @@
             "volume": "50"
         }
     }],
-    "http://registry.gpii.org/applications/org.gnome.desktop.a11y.magnifier": [{ 
+    "http://registry.gpii.org/applications/org.gnome.desktop.a11y.magnifier": [{
         "value": {
             "show-cross-hairs": true,
             "lens-mode": false,
@@ -32,7 +32,7 @@
             "scroll-at-edges": true
         }
     }],
-    "http://registry.gpii.org/applications/com.microsoft.windows.magnifier": [{ 
+    "http://registry.gpii.org/applications/com.microsoft.windows.magnifier": [{
         "value": {
             "Magnification": {
                 "value": 200,
@@ -71,7 +71,7 @@
     "http://registry.gpii.org/common/fontFaceGenericFontFace": [{ "value": "sans serif" }],
     "http://registry.gpii.org/common/magnification": [{ "value": 2.0 }],
     "http://registry.gpii.org/common/tracking": [{ "value": ["mouse"] }],
-    "http://registry.gpii.org/common/invertImages": [{ "value": true }],
+    "http://registry.gpii.org/common/invertColours": [{ "value": true }],
     "http://registry.gpii.org/common/adaptationPreference": [{ "value": [
         {
             "adaptationType": "caption",

--- a/testData/preferences/carla_24751.json
+++ b/testData/preferences/carla_24751.json
@@ -20,10 +20,10 @@
         "applications": {
             "fluid.uiOptions.windows": {
                 "name": "UI Options"
-            }, 
+            },
             "fluid.uiOptions.linux": {
                 "name": "UI Options"
-            }, 
+            },
             "fluid.uiOptions": {
                 "name": "UI Options",
                 "parameters": {
@@ -46,7 +46,7 @@
                 ],
                 "genericFontFace": "sans serif"
             },
-            
+
             "screenMagnification": {
                 "applications": {
                     "org.gnome.desktop.a11y.magnifier": {

--- a/testData/preferences/easit1.json
+++ b/testData/preferences/easit1.json
@@ -6,7 +6,7 @@
     "http://registry.gpii.org/common/fontFaceGenericFontFace": [{ "value": "SERIF" }],
     "http://registry.gpii.org/common/magnification": [{ "value": 1 }],
     "http://registry.gpii.org/common/tracking": [{ "value": ["mouse"] }],
-    "http://registry.gpii.org/common/invertImages": [{ "value": false }],
+    "http://registry.gpii.org/common/invertColours": [{ "value": false }],
     "http://registry.gpii.org/common/links": [{ "value": true }],
     "http://registry.gpii.org/common/toc": [{ "value": false }],
     "http://registry.gpii.org/common/inputsLarger": [{ "value": true }],

--- a/testData/preferences/easit2.json
+++ b/testData/preferences/easit2.json
@@ -6,7 +6,7 @@
     "http://registry.gpii.org/common/fontFaceGenericFontFace": [{ "value": "default" }],
     "http://registry.gpii.org/common/magnification": [{ "value": 1 }],
     "http://registry.gpii.org/common/tracking": [{ "value": ["mouse"] }],
-    "http://registry.gpii.org/common/invertImages": [{ "value": false }],
+    "http://registry.gpii.org/common/invertColours": [{ "value": false }],
     "http://registry.gpii.org/common/links": [{ "value": false }],
     "http://registry.gpii.org/common/toc": [{ "value": false }],
     "http://registry.gpii.org/common/inputsLarger": [{ "value": false }],

--- a/testData/preferences/os_common.json
+++ b/testData/preferences/os_common.json
@@ -2,7 +2,7 @@
     "http://registry.gpii.org/common/magnifierPosition": [{ "value": "Lens" }],
     "http://registry.gpii.org/common/magnification": [{ "value": 1.5 }],
     "http://registry.gpii.org/common/tracking": [{ "value": [ "mouse", "caret" ] }],
-    "http://registry.gpii.org/common/invertImages": [{ "value": true }],
+    "http://registry.gpii.org/common/invertColours": [{ "value": true }],
     "http://registry.gpii.org/common/cursorSize": [{ "value": 0.9 }],
     "http://registry.gpii.org/common/fontSize": [{ "value": 9 }],
     "http://registry.gpii.org/common/mouseTrailing": [{ "value": 10 }],

--- a/testData/preferences/roger.json
+++ b/testData/preferences/roger.json
@@ -5,5 +5,5 @@
 
     "http://registry.gpii.org/common/magnification": [{"value": 2.0}],
     "http://registry.gpii.org/common/tracking": [{"value": ["focus"]}],
-    "http://registry.gpii.org/common/invertImages": [{"value": false}]
+    "http://registry.gpii.org/common/invertColours": [{"value": false}]
 }

--- a/testData/preferences/sammy.json
+++ b/testData/preferences/sammy.json
@@ -6,5 +6,5 @@
     "http://registry.gpii.org/common/fontFaceGenericFontFace": [{"value": "sans serif"}],
     "http://registry.gpii.org/common/magnification": [{"value": 2.0}],
     "http://registry.gpii.org/common/tracking": [{"value": ["mouse"]}],
-    "http://registry.gpii.org/common/invertImages": [{"value": true}]
+    "http://registry.gpii.org/common/invertColours": [{"value": true}]
 }

--- a/testData/solutions/win32.json
+++ b/testData/solutions/win32.json
@@ -29,7 +29,7 @@
                         }
                     },
                     "Invert": {
-                        "value": "display.screenEnhancement.invertImages",
+                        "value": "display.screenEnhancement.-provisional-invertColours",
                         "dataType": {
                             "literalValue": "REG_DWORD"
                         }


### PR DESCRIPTION
including tests to ensure we were consistent across the codebase. In case of entries of the old ISO-2751 standard, I'm following our standards of adding a '-provisional-' prefix. Also cleaned up a few stray whitespaces
