### PR TITLE
GPII-453: Update the definition of "language" as a common term

### DIFF
--- a/testData/ontologies/ISO24751-2/flat.json
+++ b/testData/ontologies/ISO24751-2/flat.json
@@ -56,7 +56,7 @@
         "control.structuralNavigation.tableOfContents": "{http://registry.gpii.org/common/tableOfContents}.0.value",
 
         "-provisional-general.-provisional-volume": "{http://registry.gpii.org/common/volume}.0.value",
-        "language": "{http://registry.gpii.org/common/language}.0.value",
+        "-provisional-general.-provisional-language": "{http://registry.gpii.org/common/language}.0.value",
         "": {
             "transform": {
                 "type": "gpii.ontologyServer.transform.application",

--- a/testData/ontologies/ontologies.json
+++ b/testData/ontologies/ontologies.json
@@ -57,7 +57,7 @@
             "control.structuralNavigation.tableOfContents": "{http://registry.gpii.org/common/tableOfContents}.0.value",
 
             "-provisional-general.-provisional-volume": "{http://registry.gpii.org/common/volume}.0.value",
-            "language": "{http://registry.gpii.org/common/language}.0.value",
+            "-provisional-general.-provisional-language": "{http://registry.gpii.org/common/language}.0.value",
             "": {
                 "transform": {
                     "type": "gpii.ontologyServer.transform.application",


### PR DESCRIPTION
We would like to call it "-provisional-general.-provisional-language"
instead of just "language", as we're already doing with "volume" common
term.
