### PR TITLE
GPII-224: Renamed all entries of the gnome onscreen keyboard to have the correct name according to the JIRA description

### DIFF
--- a/testData/deviceReporter/installedSolutions.json
+++ b/testData/deviceReporter/installedSolutions.json
@@ -12,7 +12,7 @@
     },
     
     {
-        "id": "org.gnome.desktop.a11y.caribou-keyboard"
+        "id": "org.gnome.desktop.a11y.applications.onscreen-keyboard"
     },
     
     {

--- a/testData/deviceReporter/linux_installedSolutions.json
+++ b/testData/deviceReporter/linux_installedSolutions.json
@@ -17,7 +17,7 @@
         },
         
         {
-            "id": "org.gnome.desktop.a11y.caribou-keyboard"
+            "id": "org.gnome.desktop.a11y.applications.onscreen-keyboard"
         },
         
         {

--- a/testData/deviceReporter/osx_installedSolutions.json
+++ b/testData/deviceReporter/osx_installedSolutions.json
@@ -17,10 +17,6 @@
         },
         
         {
-            "id": "org.gnome.desktop.a11y.caribou-keyboard"
-        },
-        
-        {
             "id": "org.gnome.orca"
         },
         

--- a/testData/deviceReporter/win32_installedSolutions.json
+++ b/testData/deviceReporter/win32_installedSolutions.json
@@ -17,10 +17,6 @@
         },
 
         {
-            "id": "org.gnome.desktop.a11y.caribou-keyboard"
-        },
-
-        {
             "id": "org.gnome.orca"
         },
 

--- a/testData/preferences/nisha.json
+++ b/testData/preferences/nisha.json
@@ -23,7 +23,7 @@
             "volume": "50"
         }
     }],
-    "http://registry.gpii.org/applications/org.gnome.desktop.a11y.caribou-keyboard": [{ "value": {}}],
+    "http://registry.gpii.org/applications/org.gnome.desktop.a11y.applications.onscreen-keyboard": [{ "value": {}}],
     "http://registry.gpii.org/applications/com.microsoft.windows.onscreenKeyboard": [{ "value": {}}],
     "http://registry.gpii.org/applications/org.gnome.desktop.a11y.keyboard": [{ 
         "value": {

--- a/testData/solutions/linux.json
+++ b/testData/solutions/linux.json
@@ -263,8 +263,8 @@
     },
 
     {
-        "name": "GNOME Caribou Onscreen Keyboard",
-        "id": "org.gnome.desktop.a11y.caribou-keyboard",
+        "name": "GNOME Assistive Technology - Screen Keyboard",
+        "id": "org.gnome.desktop.a11y.applications.onscreen-keyboard",
         "contexts": {
             "OS": [{
                 "id": "linux",
@@ -276,8 +276,8 @@
                 "type": "gpii.settingsHandlers.noSettings",
                 "capabilities": [
                     "control.onscreenKeyboard",
-                    "control.onscreenKeyboard.applications.org\\.gnome\\.desktop\\.a11y\\.caribou-keyboard.name",
-                    "applications.org\\.gnome\\.desktop\\.a11y\\.caribou-keyboard.id"
+                    "control.onscreenKeyboard.applications.org\\.gnome\\.desktop\\.a11y\\.applications\\.onscreen-keyboard.name",
+                    "applications.org\\.gnome\\.desktop\\.a11y\\.applications\\.onscreen-keyboard.id"
                 ]
             }
         ],


### PR DESCRIPTION
Also removed entries from the win32 and mac device reporter payloads
