### PR TITLE
GPII-609: Removing sessions from framework

### DIFF
--- a/gpii/node_modules/flowManager/configs/development.json
+++ b/gpii/node_modules/flowManager/configs/development.json
@@ -18,7 +18,6 @@
         }
     },
     "includes": [
-        "./base.json",
-        "./io.json"
+        "./base.json"
     ]
 }

--- a/testData/preferences/os_common.json
+++ b/testData/preferences/os_common.json
@@ -1,0 +1,10 @@
+{
+    "http://registry.gpii.org/common/magnifierPosition": [{ "value": "Lens" }],
+    "http://registry.gpii.org/common/magnification": [{ "value": 1.5 }],
+    "http://registry.gpii.org/common/tracking": [{ "value": [ "mouse", "caret" ] }],
+    "http://registry.gpii.org/common/invertColours": [{ "value": true }],
+    "http://registry.gpii.org/common/cursorSize": [{ "value": 0.9 }],
+    "http://registry.gpii.org/common/fontSize": [{ "value": 9 }],
+    "http://registry.gpii.org/common/mouseTrailing": [{ "value": 10 }],
+    "http://registry.gpii.org/common/highContrastEnabled": [{ "value": true }]
+}

--- a/testData/preferences/os_common.txt
+++ b/testData/preferences/os_common.txt
@@ -1,0 +1,3 @@
+The os_common.json file is used by one of the universal unit tests - it also has an identical twin (copy) in the preferences/acceptanceTests folder, where it's being used by acceptance tests.
+
+We are in the process of cleaning up the preferences folder, and this file should be considered moved to a different folder, eg. "unitTests" subfolder of preferences.


### PR DESCRIPTION
Removed inclusion of io.json config file, disabling sessions in the framework.

Re-added os_common.json, as the removal of it resulted in the test gpii/node_modules/matchMaker/test/ProxyTests.js failing. With that file, a .txt equivalent has been added, describing the desire to move it from the preferences folder
