### PR TITLE
GPII-526: Removed screenReaderTTSEnabled transformation from the NVDA

### DIFF
--- a/testData/solutions/win32.json
+++ b/testData/solutions/win32.json
@@ -317,28 +317,6 @@
                                 "caret": "reviewCursor\\.followCaret",
                                 "mouse": "reviewCursor\\.followMouse"
                             }
-                        },
-                        {
-                            "type": "fluid.transforms.valueMapper",
-                            "inputPath": "display.screenReader.-provisional-screenReaderTTSEnabled",
-                            "options": {
-                                "false": {
-                                    "outputValue": {
-                                        "transform": [
-                                            {
-                                                "type": "fluid.transforms.literalValue",
-                                                "value": "silence",
-                                                "outputPath": "speech\\.synth"
-                                            },
-                                            {
-                                                "type": "fluid.transforms.literalValue",
-                                                "value": "Microsoft Sound Mapper",
-                                                "outputPath": "speech\\.outputDevice"
-                                            }
-                                        ]
-                                    }
-                                }
-                            }
                         }
                     ],
                     "speech\\.espeak\\.rate": {


### PR DESCRIPTION
Removed screenReaderTTSEnabled transformation from the NVDAsolution registry as it didn't really make much sense to use there. That common term is rather a flag to the matchmaker to launch/not launch a screenreader. Plus it had the unfortunate side-effect to always launch screenreader, which screenReaderTTSEnabled=false is a request not to have happen
