### PR TITLE
GPII-658: Added new configuration to be used for second pilots

### DIFF
--- a/gpii/configs/pilot2.json
+++ b/gpii/configs/pilot2.json
@@ -15,7 +15,7 @@
     "includes": [
         "../node_modules/deviceReporter/configs/development.json",
         "../node_modules/flowManager/configs/pilot2.json",
-        "../node_modules/matchMaker/configs/proxy.json",
+        "../node_modules/matchMaker/configs/pilot2.json",
         "../node_modules/ontologyServer/configs/development.json",
         "../node_modules/lifecycleManager/configs/development.json",
         "../node_modules/solutionsRegistry/configs/development.json"

--- a/gpii/configs/pilot2.json
+++ b/gpii/configs/pilot2.json
@@ -1,0 +1,24 @@
+{
+    "typeName": "flowManager.preferencesServer.solutionsRegistry.deviceReporter.matchMaker.ontologyServer.lifecycleManagerServer.multipleMatchMakers",
+    "options": {
+        "gradeNames": ["autoInit", "fluid.littleComponent"],
+        "components": {
+            "server": {
+                "type": "kettle.server",
+                "options": {
+                    "logging": true,
+                    "port": 8081
+                }
+            }
+        }
+    },
+    "includes": [
+        "../node_modules/deviceReporter/configs/development.json",
+        "../node_modules/flowManager/configs/pilot2.json",
+        "../node_modules/matchMaker/configs/proxy.json",
+        "../node_modules/ontologyServer/configs/development.json",
+        "../node_modules/lifecycleManager/configs/development.json",
+        "../node_modules/preferencesServer/configs/development.json",
+        "../node_modules/solutionsRegistry/configs/development.json"
+    ]
+}

--- a/gpii/configs/pilot2.json
+++ b/gpii/configs/pilot2.json
@@ -1,5 +1,5 @@
 {
-    "typeName": "flowManager.preferencesServer.solutionsRegistry.deviceReporter.matchMaker.ontologyServer.lifecycleManagerServer.multipleMatchMakers",
+    "typeName": "Pilots2.configuration.multipleMatchMakers.remotePrefs",
     "options": {
         "gradeNames": ["autoInit", "fluid.littleComponent"],
         "components": {
@@ -18,7 +18,6 @@
         "../node_modules/matchMaker/configs/proxy.json",
         "../node_modules/ontologyServer/configs/development.json",
         "../node_modules/lifecycleManager/configs/development.json",
-        "../node_modules/preferencesServer/configs/development.json",
         "../node_modules/solutionsRegistry/configs/development.json"
     ]
 }

--- a/gpii/configs/pilot2.txt
+++ b/gpii/configs/pilot2.txt
@@ -1,0 +1,12 @@
+pilot2.json
+============
+
+Configuration file to be used for the second round of pilots in the CLOUD4All project.
+
+It is set up to use:
+* The multiple matchmaker configuration (ie. pointing to the online matchmakers)
+* Does NOT start a local preferences server
+* Everything else is started locally
+* The "pilot2" config of the flowmanager -
+** see universal/gpii/node_modules/flowmanager/configs/pilot2.txt
+** Roughly speaking that config expects everything to run locally except for the remote prefs server

--- a/gpii/node_modules/flowManager/configs/base.json
+++ b/gpii/node_modules/flowManager/configs/base.json
@@ -13,7 +13,12 @@
                     }
                 }
             }
-        }
+        },
+        "distributeOptions": [{
+            "source": "{that}.options.flowManagerBaseGrades",
+            "target": "{that flowManager}.options.gradeNames"
+        }],
+        "flowManagerBaseGrades": ["gpii.flowManager.base"]
     },
     "modules": [
         "flowManager"

--- a/gpii/node_modules/flowManager/configs/development.json
+++ b/gpii/node_modules/flowManager/configs/development.json
@@ -3,13 +3,9 @@
     "options": {
         "gradeNames": ["autoInit", "fluid.littleComponent"],
         "distributeOptions": [{
-            "source": "{that}.options.flowManagerDevGrades",
-            "target": "{that flowManager}.options.gradeNames"
-        }, {
             "source": "{that}.options.devUrls",
             "target": "{that flowManager}.options.urls"
         }],
-        "flowManagerDevGrades": ["gpii.flowManager.dev"],
         "devUrls": {
             "preferences": "http://localhost:%port/user/%token",
             "lifecycleManagerServer": "http://localhost:%port/%operation/%token",

--- a/gpii/node_modules/flowManager/configs/pilot2.json
+++ b/gpii/node_modules/flowManager/configs/pilot2.json
@@ -1,0 +1,20 @@
+{
+    "typeName": "flowManager.development",
+    "options": {
+        "gradeNames": ["autoInit", "fluid.littleComponent"],
+        "distributeOptions": [{
+            "source": "{that}.options.pilotUrls",
+            "target": "{that flowManager}.options.urls"
+        }],
+        "pilotUrls": {
+            "preferences": "http://preferences.gpii.net/user/%token",
+            "lifecycleManagerServer": "http://localhost:%port/%operation/%token",
+            "deviceReporter": "http://localhost:%port/device",
+            "matchMaker": "http://localhost:%port/match"
+        }
+    },
+    "includes": [
+        "./base.json",
+        "./io.json"
+    ]
+}

--- a/gpii/node_modules/flowManager/configs/pilot2.json
+++ b/gpii/node_modules/flowManager/configs/pilot2.json
@@ -1,5 +1,5 @@
 {
-    "typeName": "flowManager.development",
+    "typeName": "flowManager.pilot2.remote.preferences",
     "options": {
         "gradeNames": ["autoInit", "fluid.littleComponent"],
         "distributeOptions": [{

--- a/gpii/node_modules/flowManager/configs/pilot2.txt
+++ b/gpii/node_modules/flowManager/configs/pilot2.txt
@@ -1,0 +1,10 @@
+pilot2.json
+============
+
+Configuration file to be used for the second round of pilots in the CLOUD4All project.
+
+This file is primarily used to be referred by universal/gpii/configs/pilot2
+
+It is set up to use:
+* Remote preferences server
+* All other services locally (device reporter, lifecycle manager, matchmaker)

--- a/gpii/node_modules/flowManager/src/FlowManager.js
+++ b/gpii/node_modules/flowManager/src/FlowManager.js
@@ -93,7 +93,7 @@ https://github.com/gpii/universal/LICENSE.txt
         }
     });
 
-    fluid.defaults("gpii.flowManager.dev", {
+    fluid.defaults("gpii.flowManager.base", {
         gradeNames: ["autoInit", "fluid.littleComponent"],
         distributeOptions: {
             source: "{that}.options.urlExpanderGradeNames",

--- a/gpii/node_modules/matchMaker/configs/pilot2.json
+++ b/gpii/node_modules/matchMaker/configs/pilot2.json
@@ -12,7 +12,8 @@
                             "options": {
                                 "matchMakerPathMap": {
                                     "flat": "http://localhost:8079",
-                                    "ruleBased": "http://localhost:8078"
+                                    "ruleBased": "http://rbmm.gpii.net",
+                                    "statistical": "http://stmm.gpii.net"
                                 }
                             }
                         }

--- a/gpii/node_modules/matchMaker/configs/pilot2.txt
+++ b/gpii/node_modules/matchMaker/configs/pilot2.txt
@@ -1,0 +1,10 @@
+pilot2.json
+=================
+
+MM set up to run as a matchmaker proxy supporting 3 matchmakers:
+* ruleBased: expected to run at rbmm.gpii.net
+* statistical: expected to run at stmm.gpii.net
+* flat: local instance of the flat matchmaker on port 8079
+
+This setup is identical to proxy.json, except for where the rulebased and statistical MM are
+expected to be running

--- a/gpii/node_modules/matchMaker/configs/proxy.json
+++ b/gpii/node_modules/matchMaker/configs/proxy.json
@@ -12,7 +12,8 @@
                             "options": {
                                 "matchMakerPathMap": {
                                     "flat": "http://localhost:8079",
-                                    "ruleBased": "http://localhost:8078"
+                                    "ruleBased": "http://rbmm.gpii.net",
+                                    "statistical": "http://stmm.gpii.net"
                                 }
                             }
                         }


### PR DESCRIPTION
Added new configuration files with .txt files explaining the content. Also changed a gradename in the flowmanager to be something more sensible. The gradename was required to allow resolving of portnumbers in URLs, but was named with a surname of .dev.. has changed this to .base, as it's pretty normal behaviour to want portnumbers resolved

To test this pull request: 
1) For the change in the flowmanager, it should be sufficient to checking out this branch and running the windows and universal acceptance tests
2) The new config files are trickier to test as we dont have any acceptance tests for them. My suggestion would be to create an NP set on the preferences.gpii.net (and not have it present on the local machine): 
curl -XPOST -H 'Content-Type:application/json' -H 'Accept: application/json' --data-binary @(YOUR_NP_SET).json http://preferences.gpii.net/user/(DESIRED TOKEN NAME WITHOUT .json)
Then start up the GPII in the pilot2 environment:
SET NODE_ENV=pilot2
and login with the newly created user.. If it works fetching them from the prefs server, that part is correct.
The MM proxy part, I'm unsure how to best test... I guess the previous test will confirm that things are at least working in the state they're were at before. Until we have acceptance tests for them, I'm unsure how to best check that the rbmm and st mm are properly working. I guess theoretically adding a preference: 

"http://registry.gpii.org/common/matchMakerType": [{ "value": "statistical" }]

to any NP set on preferences.gpii.net and logging in with that should work