### PR TITLE
Pilots2: Fixing NP sets for acceptance tests

### DIFF
--- a/testData/preferences/acceptanceTests/os_common.json
+++ b/testData/preferences/acceptanceTests/os_common.json
@@ -1,4 +1,5 @@
 {
+    "http://registry.gpii.org/common/magnifierEnabled": [{ "value": true }],
     "http://registry.gpii.org/common/magnifierPosition": [{ "value": "Lens" }],
     "http://registry.gpii.org/common/magnification": [{ "value": 1.5 }],
     "http://registry.gpii.org/common/tracking": [{ "value": [ "mouse", "caret" ] }],


### PR DESCRIPTION
Still having problems when running AcceptanceTests_builtIn.js

<pre>
jq:  Expected:  {
    "gpii.gsettings": {
        "data": [
            {
                "settings": {
                    "mag-factor": 1,
                    "screen-position": "top-half"
                }
            },
            {
                "settings": {
                    "gtk-theme": "HighContrast",
                    "icon-theme": "HighContrast",
                    "cursor-size": 41
                }
            }
        ]
    }
}
jq:  Actual:  {
    "gpii.gsettings": {
        "data": [
            {
                "settings": {
                    "mag-factor": 1.5,
                    "screen-position": "full-screen"
                }
            },
            {
                "settings": {
                    "gtk-theme": "HighContrast",
                    "icon-theme": "HighContrast",
                    "cursor-size": 41
                }
            }
        ]
    }
}
</pre>


The problem is that magnifierEnabled is missing when moving preferences from one platform into another. Any idea?
