### PR TITLE
Pilots2: Only activate Talkback when ScreenReaderTTSEnabled common term is set

### DIFF
--- a/testData/solutions/android.json
+++ b/testData/solutions/android.json
@@ -46,7 +46,8 @@
                 "capabilities": [
                     "display.screenReader",
                     "applications.com\\.android\\.talkback.id",
-                    "display.screenReader.applications.com\\.android\\.talkback.name"
+                    "display.screenReader.applications.com\\.android\\.talkback.name",
+                    "display.screenReader.-provisional-screenReaderTTSEnabled"
                 ]
             }
         ],


### PR DESCRIPTION
This minor change makes the system to launch Talkback only when screenReaderTTSEnabled common term is set.
