### PR TITLE
GPII-771: device config file w/o magnification

### DIFF
--- a/testData/deviceReporter/secondPilots/platformAB_onWindows_NoMagnification.json
+++ b/testData/deviceReporter/secondPilots/platformAB_onWindows_NoMagnification.json
@@ -1,0 +1,98 @@
+[
+    {
+        "id": "org.nvda-project"
+    },
+
+    {
+        "id": "org.gnome.desktop.interface"
+    },
+
+    {
+        "id": "org.gnome.shell.overrides"
+    },
+
+    {
+        "id": "org.gnome.desktop.wm.preferences"
+    },
+
+    {
+        "id": "org.gnome.nautilus"
+    },
+
+    {
+        "id": "org.gnome.desktop.a11y.keyboard"
+    },
+
+    {
+        "id": "org.gnome.desktop.a11y.applications.onscreen-keyboard"
+    },
+
+    {
+        "id": "org.gnome.orca"
+    },
+
+    {
+        "id": "com.microsoft.windows.onscreenKeyboard"
+    },
+
+    {
+        "id": "org.gnome.desktop.interface"
+    },
+
+    {
+        "id": "org.gnome.nautilus"
+    },
+
+    {
+        "id": "com.microsoft.windows.highContrast"
+    },
+
+    {
+        "id": "com.microsoft.windows.mouseTrailing"
+    },
+
+    {
+        "id": "com.microsoft.windows.cursors"
+    },
+
+    {
+        "id": "com.android.activitymanager"
+    },
+
+    {
+        "id": "com.android.talkback"
+    },
+
+    {
+        "id": "com.android.freespeech"
+    },
+
+    {
+        "id": "org.chrome.cloud4chrome"
+    },
+
+    {
+        "id": "com.android.settings.secure"
+    },
+
+    {
+        "id": "com.android.audioManager"
+    },
+
+    {
+        "id": "com.android.persistentConfiguration"
+    },
+
+    {
+        "id": "org.alsa-project"
+    },
+
+    {
+        "id": "org.freedesktop.xrandr"
+    },
+
+    {
+        "id": "com.android.settings.system"
+    }
+
+]


### PR DESCRIPTION
This is the device reporter data that would be reported to the statistical matchmaker when the user does not want to launch a magnifier, even though his snapshotted settings contain both magnifier and screen reader settings.
