### PR TITLE
GPII-771: remove Android solutions

### DIFF
--- a/testData/deviceReporter/secondPilots/platformAB_onWindows_NoMagnification.json
+++ b/testData/deviceReporter/secondPilots/platformAB_onWindows_NoMagnification.json
@@ -56,31 +56,7 @@
     },
 
     {
-        "id": "com.android.activitymanager"
-    },
-
-    {
-        "id": "com.android.talkback"
-    },
-
-    {
-        "id": "com.android.freespeech"
-    },
-
-    {
         "id": "org.chrome.cloud4chrome"
-    },
-
-    {
-        "id": "com.android.settings.secure"
-    },
-
-    {
-        "id": "com.android.audioManager"
-    },
-
-    {
-        "id": "com.android.persistentConfiguration"
     },
 
     {
@@ -89,10 +65,6 @@
 
     {
         "id": "org.freedesktop.xrandr"
-    },
-
-    {
-        "id": "com.android.settings.system"
     }
 
 ]


### PR DESCRIPTION
This patch removes Android solutions from the device reporter file for desktops.
