### PR TITLE
Removing duplicate entries

### DIFF
--- a/testData/deviceReporter/secondPilots/platformAB_onWindows_NoMagnification.json
+++ b/testData/deviceReporter/secondPilots/platformAB_onWindows_NoMagnification.json
@@ -36,14 +36,6 @@
     },
 
     {
-        "id": "org.gnome.desktop.interface"
-    },
-
-    {
-        "id": "org.gnome.nautilus"
-    },
-
-    {
         "id": "com.microsoft.windows.highContrast"
     },
 


### PR DESCRIPTION
The following entries were duplicates:
- "org.gnome.desktop.interface" 
- "org.gnome.nautilus" 

These duplicates propagated from the original installedSolutions.json file in pilotsConfig. See my pull request at https://github.com/Cloud4AllTUD/pilotsConfig/pull/7
