### PR TITLE
GPII-915: Add missing 'false' values for gtk-theme and icon-theme in solutions/linux.json

### DIFF
--- a/testData/solutions/linux.json
+++ b/testData/solutions/linux.json
@@ -186,6 +186,9 @@
                             "options": {
                                 "true": {
                                     "outputValue": "HighContrast"
+                                },
+                                "false": {
+                                    "outputValue": "Adwaita"
                                 }
                             }
                         }
@@ -197,6 +200,9 @@
                             "options": {
                                 "true": {
                                     "outputValue": "HighContrast"
+                                },
+                                "false": {
+                                    "outputValue": "gnome"
                                 }
                             }
                         }


### PR DESCRIPTION
Link to JIRA (with issue description): http://issues.gpii.net/browse/GPII-915