### PR TITLE
GPII-1070: Added production configs for running the system locally but using remote servers

### DIFF
--- a/gpii/configs/production.with.logging.json
+++ b/gpii/configs/production.with.logging.json
@@ -1,0 +1,39 @@
+{
+    "typeName": "production.with.logging",
+    "options": {
+        "gradeNames": ["autoInit", "fluid.littleComponent"],
+        "components": {
+            "server": {
+                "type": "kettle.server",
+                "options": {
+                    "logging": true,
+                    "port": 8081
+                }
+            }
+        },
+        "devUrls": {
+            "preferences": "http://preferences.gpii.net/preferences/%userToken",
+            "deviceReporter": "http://localhost:%port/device",
+            "solutionsRegistry": "file://%root/../../../testData/solutions/%os.json"
+        },
+        "matchMakers": {
+            "flat": {
+                "url": "http://localhost:8081"
+            },
+            "Statistical": {
+                "url": "http://stmm.gpii.net"
+            },
+            "RuleBased": {
+                "url": "http://rbmm.gpii.net"
+            }
+        }
+    },
+    "includes": [
+        "../node_modules/deviceReporter/configs/development.json",
+        "../node_modules/flowManager/configs/development.json",
+        "../node_modules/preferencesServer/configs/development.json",
+        "../node_modules/solutionsRegistry/configs/development.json",
+        "../node_modules/flatMatchMaker/configs/development.all.local.json",
+        "../node_modules/rawPreferencesServer/configs/development.json"
+    ]
+}

--- a/gpii/configs/production.with.logging.txt
+++ b/gpii/configs/production.with.logging.txt
@@ -1,0 +1,17 @@
+production.with.logging.json
+==========================
+
+This configuration runs the system in production mode, but keeps the logging enabled. 'production mode' means that the following services are expected to be available:
+
+* http://stmm.gpii.net - the statistical matchmaker
+* http://rbmm.gpii.net - the rule based matchmaker
+* http://preferences.gpii.net - the preferences server
+
+* The following components are running on the local machine:
+** flowManager
+** OntologyHandler
+** solutionsRegistry (reading registry from file)
+** deviceReporter (reading device context info from file)
+** matchMakerFramework
+** flatMatchMaker
+** lifecycleManager

--- a/gpii/configs/production.with.logging.txt
+++ b/gpii/configs/production.with.logging.txt
@@ -15,3 +15,7 @@ This configuration runs the system in production mode, but keeps the logging ena
 ** matchMakerFramework
 ** flatMatchMaker
 ** lifecycleManager
+
+**WARNING: This config has been tested manually leading up to and during the review meeting (Jan. 2015).
+It is NOT regularly tested by acceptance/integration or unit tests and therefore cannot be fully trusted.**
+

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "node-uuid": "~1.4.0",
         "semver": "~1.1.4",
         "xml-mapping": "~1.2.0",
-        "kettle": "git://github.com/fluid-project/kettle.git#5a2e8b8fb5b198b266d6b7b7d0d9eb94185a3759"
+        "kettle": "git://github.com/fluid-project/kettle.git#27a3bf7cfd51f62e66b45bc1b7bae9f407052586"
     },
     "devDependencies": {
         "jqUnit": "git://github.com/fluid-project/node-jqUnit.git#b7ef53aac1ca365bf23d35d255fae874faa88b70",


### PR DESCRIPTION
Added production configs for running the system locally but using remote servers:
* Remote preferences server at: http://preferences.gpii.net
* Remote Statistical MM at: http://stmm.gpii.net
* Remote Rule Based MM at: http://rbmm.gpii.net

Tested it manually, but does not have any unit/integration tests for it