### PR TITLE
Fix magnification and condition issue

### DIFF
--- a/testData/preferences/li.json
+++ b/testData/preferences/li.json
@@ -7,7 +7,7 @@
                     "http://registry.gpii.net/common/screenReaderTTSEnabled": true,
                     "http://registry.gpii.net/common/speechRate": 200,
                     "http://registry.gpii.net/common/magnifierEnabled": true,
-                    "http://registry.gpii.net/common/magnification": 1.5,
+                    "http://registry.gpii.net/common/magnification": 2,
                     "http://registry.gpii.net/common/matchMakerType": "RuleBased"
                 },
                 "metadata": [
@@ -27,7 +27,7 @@
                     "http://registry.gpii.net/common/screenReaderTTSEnabled": true,
                     "http://registry.gpii.net/common/speechRate": 200,
                     "http://registry.gpii.net/common/magnifierEnabled": true,
-                    "http://registry.gpii.net/common/magnification": 2,
+                    "http://registry.gpii.net/common/magnification": 3,
                     "http://registry.gpii.net/common/highContrastEnabled": true,
                     "http://registry.gpii.net/common/matchMakerType": "RuleBased"
                 },
@@ -44,6 +44,7 @@
                 "conditions": [
                     {
                         "type": "http://registry.gpii.net/conditions/inRange",
+						"max": 400000,
                         "min": 400,
                         "inputPath": "http://registry\\.gpii\\.net/common/environment/visual\\.luminance"
                     }

--- a/testData/preferences/vladimir.json
+++ b/testData/preferences/vladimir.json
@@ -68,6 +68,7 @@
                 "conditions": [
                     {
                         "type": "http://registry.gpii.net/conditions/inRange",
+						"max": 400000,
                         "min": 400,
                         "inputPath": "http://registry\\.gpii\\.net/common/environment/visual\\.luminance"
                     }

--- a/testData/preferences/vladimir_smm.json
+++ b/testData/preferences/vladimir_smm.json
@@ -68,6 +68,7 @@
                 "conditions": [
                     {
                         "type": "http://registry.gpii.net/conditions/inRange",
+						"max":400000,
                         "min": 400,
                         "inputPath": "http://registry\\.gpii\\.net/common/environment/visual\\.luminance"
                     }


### PR DESCRIPTION
* Change magnification from 1.5 to 2 for gpii-default as Supernova can
only handle integer.
* Add max value to condition block. Required to work with the RBMM.