### PR TITLE
GPII-1022: Add support for ColorNote (and Android's native browser)

### DIFF
--- a/testData/deviceReporter/installedSolutions_with_androidbrowser.json
+++ b/testData/deviceReporter/installedSolutions_with_androidbrowser.json
@@ -1,0 +1,114 @@
+[
+    {
+        "id": "org.nvda-project"
+    },
+
+    {
+        "id": "org.gnome.desktop.interface"
+    },
+
+    {
+        "id": "org.gnome.shell.overrides"
+    },
+
+    {
+        "id": "org.gnome.desktop.wm.preferences"
+    },
+
+    {
+        "id": "org.gnome.nautilus"
+    },
+
+    {
+        "id": "org.gnome.desktop.a11y.keyboard"
+    },
+
+    {
+        "id": "org.gnome.desktop.a11y.applications.onscreen-keyboard"
+    },
+
+    {
+        "id": "org.gnome.orca"
+    },
+
+    {
+        "id": "org.gnome.desktop.a11y.magnifier"
+    },
+
+    {
+        "id": "com.microsoft.windows.magnifier"
+    },
+
+    {
+        "id": "com.microsoft.windows.onscreenKeyboard"
+    },
+
+    {
+        "id": "org.gnome.desktop.interface"
+    },
+
+    {
+        "id": "org.gnome.nautilus"
+    },
+
+    {
+        "id": "com.microsoft.windows.highContrast"
+    },
+
+    {
+        "id": "com.microsoft.windows.mouseTrailing"
+    },
+
+    {
+        "id": "com.microsoft.windows.cursors"
+    },
+
+    {
+        "id": "com.android.activitymanager"
+    },
+
+    {
+        "id": "com.android.talkback"
+    },
+
+    {
+        "id": "com.android.freespeech"
+    },
+
+    {
+        "id": "org.chrome.cloud4chrome"
+    },
+
+    {
+        "id": "com.android.settings.secure"
+    },
+
+    {
+        "id": "com.android.audioManager"
+    },
+
+    {
+        "id": "com.android.persistentConfiguration"
+    },
+
+    {
+        "id": "org.alsa-project"
+    },
+
+    {
+        "id": "org.freedesktop.xrandr"
+    },
+
+    {
+        "id": "com.android.settings.system"
+    },
+
+    {
+        "id": "com.socialnmobile.dictapps.notepad.color.note"
+    },
+
+    {
+        "id": "com.android.browser"
+    }
+
+]

--- a/testData/deviceReporter/installedSolutions_with_colornote.json
+++ b/testData/deviceReporter/installedSolutions_with_colornote.json
@@ -1,0 +1,110 @@
+[
+    {
+        "id": "org.nvda-project"
+    },
+
+    {
+        "id": "org.gnome.desktop.interface"
+    },
+
+    {
+        "id": "org.gnome.shell.overrides"
+    },
+
+    {
+        "id": "org.gnome.desktop.wm.preferences"
+    },
+
+    {
+        "id": "org.gnome.nautilus"
+    },
+
+    {
+        "id": "org.gnome.desktop.a11y.keyboard"
+    },
+
+    {
+        "id": "org.gnome.desktop.a11y.applications.onscreen-keyboard"
+    },
+
+    {
+        "id": "org.gnome.orca"
+    },
+
+    {
+        "id": "org.gnome.desktop.a11y.magnifier"
+    },
+
+    {
+        "id": "com.microsoft.windows.magnifier"
+    },
+
+    {
+        "id": "com.microsoft.windows.onscreenKeyboard"
+    },
+
+    {
+        "id": "org.gnome.desktop.interface"
+    },
+
+    {
+        "id": "org.gnome.nautilus"
+    },
+
+    {
+        "id": "com.microsoft.windows.highContrast"
+    },
+
+    {
+        "id": "com.microsoft.windows.mouseTrailing"
+    },
+
+    {
+        "id": "com.microsoft.windows.cursors"
+    },
+
+    {
+        "id": "com.android.activitymanager"
+    },
+
+    {
+        "id": "com.android.talkback"
+    },
+
+    {
+        "id": "com.android.freespeech"
+    },
+
+    {
+        "id": "org.chrome.cloud4chrome"
+    },
+
+    {
+        "id": "com.android.settings.secure"
+    },
+
+    {
+        "id": "com.android.audioManager"
+    },
+
+    {
+        "id": "com.android.persistentConfiguration"
+    },
+
+    {
+        "id": "org.alsa-project"
+    },
+
+    {
+        "id": "org.freedesktop.xrandr"
+    },
+
+    {
+        "id": "com.android.settings.system"
+    },
+
+    {
+        "id": "com.socialnmobile.dictapps.notepad.color.note"
+    }
+
+]

--- a/testData/preferences/androidbrowser.json
+++ b/testData/preferences/androidbrowser.json
@@ -1,0 +1,3 @@
+{
+    "http://registry.gpii.org/applications/com.android.browser": [{"value":{"map.boolean.inverted":"true"}}]
+}

--- a/testData/preferences/colornote.json
+++ b/testData/preferences/colornote.json
@@ -1,0 +1,5 @@
+{
+    "http://registry.gpii.org/common/highContrastEnabled": [{"value": true }],
+    "http://registry.gpii.org/common/highContrastTheme": [{"value": "COLORTABLE/DARK" }],
+    "http://registry.gpii.org/applications/com.socialnmobile.dictapps.notepad.color.note": [{"value":{"map.string.pref_default_font_size.$t":"32"}}]
+}

--- a/testData/solutions/android.json
+++ b/testData/solutions/android.json
@@ -596,5 +596,141 @@
                 }
             }
         ]
+    },
+
+    "com.socialnmobile.dictapps.notepad.color.note": {
+        "name": "Color Note",
+	"contexts": {
+	    "OS": [
+	        {
+	            "id": "android",
+	            "version": ">=0.1"
+	        }
+	    ]
+	},
+	"settingsHandlers": [
+	    {
+	        "type": "gpii.settingsHandlers.XMLHandler.set",
+	        "options": {
+	            "filename": "/data/data/com.socialnmobile.dictapps.notepad.color.note/shared_prefs/com.socialnmobile.dictapps.notepad.color.note_preferences.xml",
+	            "encoding": "utf-8",
+	            "xml-tag": "<?xml version='1.0' encoding='utf-8' standalone='yes' ?>",
+	            "rules": {
+	                "map": "map",
+	                "map.string": {
+	                    "transform": {
+	                        "type": "fluid.transforms.arrayToObject",
+	                        "inputPath": "map.string",
+	                        "key": "name"
+	                    }
+	                }
+	            }
+	        },
+	        "capabilities": [
+	            "applications.com\\.socialnmobile\\.dictapps\\.notepad\\.color\\.note.id"
+	        ],
+	        "capabilitiesTransformations": {
+	            "map\\.string\\.PREF_THEME\\.$t": {
+	                "transform": {
+	                    "type": "fluid.transforms.condition",
+	                    "conditionPath": "http://registry\\.gpii\\.net/common/highContrastEnabled",
+	                    "true": "COLORTABLE/DARK",
+	                    "truePath": "http://registry\\.gpii\\.net/common/highContrastTheme",
+	                    "false": "none"
+	                }
+	            }
+	        }
+	    }
+	],
+        "lifecycleManager": {
+            "start": [
+                "setSettings",
+                {
+                    "type": "gpii.androidActivityManager.startActivityByPackageName",
+                    "packageName": "com.socialnmobile.dictapps.notepad.color.note"
+                }
+            ],
+            "stop": [
+                {
+                    "type": "gpii.androidActivityManager.stopActivityByPackageName",
+                    "packageName": "com.socialnmobile.dictapps.notepad.color.note"
+                },
+                "restoreSettings",
+                {
+                    "type": "gpii.androidActivityManager.goToHomeScreen"
+                }
+            ]
+        }
+    },
+
+    "com.android.browser": {
+        "name": "Android Browser",
+        "contexts": {
+            "OS": [{
+                "id": "android",
+                "version": ">=0.1"
+            }]
+        },
+        "settingsHandlers": [
+            {
+                "type": "gpii.settingsHandlers.XMLHandler.set",
+                "options": {
+                    "filename": "/data/data/com.android.browser/shared_prefs/com.android.browser_preferences.xml",
+                    "encoding": "utf-8",
+                    "xml-tag": "<?xml version='1.0' encoding='utf-8' standalone='yes' ?>",
+                    "rules": {
+                        "map": "map",
+                        "map.boolean": {
+                            "transform": {
+                                "type": "fluid.transforms.arrayToObject",
+                                "inputPath": "map.boolean",
+                                "key": "name",
+                                "innerValue": [{
+                                    "transform": {
+                                        "type":"fluid.transforms.value",
+                                        "inputPath": "value"
+                                    }
+                                }]
+                            }
+                        },
+                        "map.int": {
+                            "transform": {
+                                "type": "fluid.transforms.arrayToObject",
+                                "inputPath": "map.int",
+                                "key": "name",
+                                "innerValue": [{
+                                    "transform": {
+                                        "type":"fluid.transforms.value",
+                                        "inputPath": "value"
+                                    }
+                                }]
+                            }
+                        }
+                    }
+                },
+                "capabilities": [
+                    "applications.com\\.android\\.browser.id"
+                ]
+            }
+        ],
+        "lifecycleManager": {
+            "start": [
+                "setSettings",
+                {
+                    "type": "gpii.androidActivityManager.startActivityByPackageName",
+                    "packageName": "com.android.browser"
+                }
+            ],
+            "stop": [
+                {
+                    "type": "gpii.androidActivityManager.stopActivityByPackageName",
+                    "packageName": "com.android.browser"
+                },
+                "restoreSettings",
+                {
+                    "type": "gpii.androidActivityManager.goToHomeScreen"
+                }
+            ]
+        }
     }
 }


### PR DESCRIPTION
Initially, GPII-1022 was created in order to keep track of the implementation of ColorNote, but the original author included an initial implementation of the android browser. I'm just making a proper pull request with the original commits (https://github.com/Diegohp/universal/tree/GPII-1022_FVE) and updating the solutions registry entries a bit (just adapted them to the new format).

@Diegohp, although this can be used for a demo, to land master it still needs some more work:
* Update the NP sets to the new format
* Create tests
* Describe the solution
