### PR TITLE
GPII-629: Changed the linux aceptance/integration tests to remove 'data' references

### DIFF
--- a/tests/platform/android/android-builtIn-testSpec.js
+++ b/tests/platform/android/android-builtIn-testSpec.js
@@ -26,7 +26,7 @@ gpii.tests.android.builtIn = [
         userToken: "os_android",
         settingsHandlers: {
             "gpii.androidSettings": {
-                "data": [{
+                "some.app.id": [{
                     "settings": {
                         "dim_screen": 1,
                         "haptic_feedback_enabled": 1,
@@ -40,14 +40,14 @@ gpii.tests.android.builtIn = [
                 }]
             },
             "gpii.androidAudioManager.volume": {
-                "data": [{
+                "some.app.id": [{
                     "settings": {
                         "STREAM_SYSTEM": 7
                     }
                 }]
             },
             "gpii.androidPersistentConfiguration": {
-                "data": [{
+                "some.app.id": [{
                     "settings": {
                         "fontScale": 1.5,
                         "locale": "en"
@@ -61,7 +61,7 @@ gpii.tests.android.builtIn = [
         userToken: "os_android_common",
         settingsHandlers: {
             "gpii.androidSettings": {
-                "data": [{
+                "some.app.id": [{
                     "settings": {
                         "dim_screen": 1,
                         "haptic_feedback_enabled": 1,
@@ -75,14 +75,14 @@ gpii.tests.android.builtIn = [
                 }]
             },
             "gpii.androidAudioManager.volume": {
-                "data": [{
+                "some.app.id": [{
                     "settings": {
                         "STREAM_SYSTEM": 4
                     }
                 }]
             },
             "gpii.androidPersistentConfiguration": {
-                "data": [{
+                "some.app.id": [{
                     "settings": {
                         "fontScale": 2,
                         "locale": "en_GB"
@@ -96,7 +96,7 @@ gpii.tests.android.builtIn = [
         userToken: "os_gnome",
         settingsHandlers: {
             "gpii.androidPersistentConfiguration": {
-                "data": [{
+                "some.app.id": [{
                     "settings": {
                         "fontScale": 0.75
                     }
@@ -109,7 +109,7 @@ gpii.tests.android.builtIn = [
         userToken: "os_common",
         settingsHandlers: {
             "gpii.androidPersistentConfiguration": {
-                "data": [{
+                "some.app.id": [{
                     "settings": {
                         "fontScale": 0.75
                     }

--- a/tests/platform/android/android-talkback-testSpec.js
+++ b/tests/platform/android/android-talkback-testSpec.js
@@ -24,7 +24,7 @@ gpii.tests.android.talkback = [
         userToken: "talkback1",
         settingsHandlers: {
             "gpii.androidAudioManager.volume": {
-                "data": [
+                "some.app.id": [
                     {
                         "settings": {
                             "STREAM_MUSIC": 14
@@ -33,7 +33,7 @@ gpii.tests.android.talkback = [
                 ]
             },
             "gpii.androidSettings": {
-                "data": [
+                "some.app.id": [
                     {
                         "settings": {
                             "tts_default_rate": 450,
@@ -52,7 +52,7 @@ gpii.tests.android.talkback = [
         userToken: "talkback2",
         settingsHandlers: {
             "gpii.androidSettings": {
-                "data": [
+                "some.app.id": [
                     {
                         "settings": {
                             "tts_default_rate": 496,
@@ -71,7 +71,7 @@ gpii.tests.android.talkback = [
         userToken: "screenreader_orca",
         settingsHandlers: {
             "gpii.androidSettings": {
-                "data": [
+                "some.app.id": [
                     {
                         "settings": {
                             "tts_default_rate": 681
@@ -89,7 +89,7 @@ gpii.tests.android.talkback = [
         userToken: "screenreader_nvda",
         settingsHandlers: {
             "gpii.androidSettings": {
-                "data": [
+                "some.app.id": [
                     {
                         "settings": {
                             "tts_default_rate": 681
@@ -107,7 +107,7 @@ gpii.tests.android.talkback = [
         userToken: "screenreader_common",
         settingsHandlers: {
             "gpii.androidAudioManager.volume": {
-                "data": [
+                "some.app.id": [
                     {
                         "settings": {
                             "STREAM_MUSIC": 11
@@ -116,7 +116,7 @@ gpii.tests.android.talkback = [
                 ]
             },
             "gpii.androidSettings": {
-                "data": [
+                "some.app.id": [
                     {
                         "settings": {
                             "tts_default_rate": 681,

--- a/tests/platform/linux/linux-builtIn-testSpec.js
+++ b/tests/platform/linux/linux-builtIn-testSpec.js
@@ -27,7 +27,7 @@ gpii.tests.linux.builtIn = [
         userToken: "os_common",
         settingsHandlers: {
             "gpii.gsettings": {
-                "data": [{
+                "some.app.id": [{
                     "settings": {
                         "mag-factor": 1.5,
                         "screen-position": "full-screen"
@@ -61,7 +61,7 @@ gpii.tests.linux.builtIn = [
         userToken: "os_gnome",
         settingsHandlers: {
             "gpii.gsettings": {
-                "data": [{
+                "some.app.id": [{
                     "settings": {
                         "mag-factor": 1.5,
                         "screen-position": "full-screen"
@@ -80,7 +80,7 @@ gpii.tests.linux.builtIn = [
                 }]
             },
             "gpii.alsa": {
-                "data": [{
+                "some.app.id": [{
                     "settings": {
                         "masterVolume": 50
                     }
@@ -100,7 +100,7 @@ gpii.tests.linux.builtIn = [
         userToken: "os_win7",
         settingsHandlers: {
             "gpii.gsettings": {
-                "data": [{
+                "some.app.id": [{
                     "settings": {
                         "mag-factor": 1.5,
                         "screen-position": "full-screen"

--- a/tests/platform/linux/linux-orca-testSpec.js
+++ b/tests/platform/linux/linux-orca-testSpec.js
@@ -24,7 +24,7 @@ gpii.tests.linux.orca = [
         userToken: "screenreader_common",
         settingsHandlers: {
             "gpii.orca": {
-                "data": [
+                "some.app.id": [
                     {
                         "settings": {
                             "sayAllStyle": 1,
@@ -61,7 +61,7 @@ gpii.tests.linux.orca = [
         userToken: "screenreader_orca",
         settingsHandlers: {
             "gpii.orca": {
-                "data": [
+                "some.app.id": [
                     {
                         "settings": {
                             "sayAllStyle": 1,
@@ -97,7 +97,7 @@ gpii.tests.linux.orca = [
         userToken: "screenreader_nvda",
         settingsHandlers: {
             "gpii.orca": {
-                "data": [
+                "some.app.id": [
                     {
                         "settings": {
                             "sayAllStyle": 1,

--- a/tests/platform/windows/windows-builtIn-testSpec.js
+++ b/tests/platform/windows/windows-builtIn-testSpec.js
@@ -25,7 +25,7 @@ gpii.tests.windows.builtIn = [
         userToken: "os_win7",
         settingsHandlers: {
             "gpii.windows.spiSettingsHandler": {
-                "data": [
+                "some.app.id": [
                     {
                         "settings": {
                             "MouseTrails": {
@@ -64,7 +64,7 @@ gpii.tests.windows.builtIn = [
                 ]
             },
             "gpii.windows.registrySettingsHandler": {
-                "data": [{ // magnifier stuff
+                "some.app.id": [{ // magnifier stuff
                     "settings": {
                         "Invert": 1,
                         "Magnification": 150,
@@ -135,7 +135,7 @@ gpii.tests.windows.builtIn = [
         userToken: "os_common",
         settingsHandlers: {
             "gpii.windows.spiSettingsHandler": {
-                "data": [
+                "some.app.id": [
                     {
                         "settings": {
                             "MouseTrails": {
@@ -174,7 +174,7 @@ gpii.tests.windows.builtIn = [
                 ]
             },
             "gpii.windows.registrySettingsHandler": {
-                "data": [{ // magnifier stuff
+                "some.app.id": [{ // magnifier stuff
                     "settings": {
                         "Invert": 1,
                         "Magnification": 150,
@@ -245,7 +245,7 @@ gpii.tests.windows.builtIn = [
         userToken: "os_gnome",
         settingsHandlers: {
             "gpii.windows.registrySettingsHandler": {
-                "data": [{ // magnifier stuff
+                "some.app.id": [{ // magnifier stuff
                     "settings": {
                         "Magnification": 150,
                         "MagnificationMode": 2

--- a/tests/platform/windows/windows-jaws-testSpec.js
+++ b/tests/platform/windows/windows-jaws-testSpec.js
@@ -25,7 +25,7 @@ gpii.tests.windows.jaws = [
         userToken: "jaws_application",
         settingsHandlers: {
             "gpii.settingsHandlers.INISettingsHandler": {
-                "data": [
+                "some.app.id": [
                     {
                         "settings": {
                             "cloud4allVoiceProfile-GlobalContext.Speed": 115
@@ -49,7 +49,7 @@ gpii.tests.windows.jaws = [
         userToken: "jaws_common",
         settingsHandlers: {
             "gpii.settingsHandlers.INISettingsHandler": {
-                "data": [
+                "some.app.id": [
                     {
                         "settings": {
                             "cloud4allVoiceProfile-GlobalContext.Speed": 37.875,

--- a/tests/platform/windows/windows-nvda-testSpec.js
+++ b/tests/platform/windows/windows-nvda-testSpec.js
@@ -25,7 +25,7 @@ gpii.tests.windows.nvda = [
         userToken: "screenreader_nvda",
         settingsHandlers: {
             "gpii.settingsHandlers.INISettingsHandler": {
-                "data": [
+                "some.app.id": [
                     {
                         "settings": {
                             "speech.espeak.rate": 17.20430107526882,
@@ -66,7 +66,7 @@ gpii.tests.windows.nvda = [
         userToken: "screenreader_common",
         settingsHandlers: {
             "gpii.settingsHandlers.INISettingsHandler": {
-                "data": [
+                "some.app.id": [
                     {
                         "settings": {
                             "speech.espeak.rate": 17.20430107526882,
@@ -105,7 +105,7 @@ gpii.tests.windows.nvda = [
         userToken: "screenreader_orca",
         settingsHandlers: {
             "gpii.settingsHandlers.INISettingsHandler": {
-                "data": [
+                "some.app.id": [
                     {
                         "settings": {
                             "speech.symbolLevel": 300,


### PR DESCRIPTION
so we're no longer dependent on the 'data' key when using the orca settingshandler, by replacing entries of 'data' with something similar to a solution ID