### PR TITLE
GPII-707: readingUnit != autoSayAllOnPageLoad

### DIFF
--- a/testData/solutions/win32.json
+++ b/testData/solutions/win32.json
@@ -302,21 +302,6 @@
                     "keyboard\\.speakTypedCharacters": "http://registry\\.gpii\\.net/common/keyEcho",
                     "keyboard\\.speakTypedWords": "http://registry\\.gpii\\.net/common/wordEcho",
                     "speech\\.espeak\\.sayCapForCapitals": "http://registry\\.gpii\\.net/common/announceCapitals",
-                    "virtualBuffers\\.autoSayAllOnPageLoad": {
-                        "transform": {
-                            "type": "fluid.transforms.valueMapper",
-                            "inputPath": "http://registry\\.gpii\\.net/common/readingUnit",
-                            "defaultInputValue": "sentence",
-                            "options": {
-                                "all": {
-                                    "outputValue": true
-                                },
-                                "sentence": {
-                                    "outputValue": false
-                                }
-                            }
-                        }
-                    },
                     "transform": [
                         {
                             "type": "fluid.transforms.arrayToSetMembership",

--- a/tests/platform/windows/windows-nvda-testSpec.js
+++ b/tests/platform/windows/windows-nvda-testSpec.js
@@ -32,7 +32,6 @@ gpii.tests.windows.nvda = [
                             "speech.espeak.volume": 80,
                             "speech.espeak.pitch": 60,
                             "speech.espeak.rateBoost": true,
-                            "virtualBuffers.autoSayAllOnPageLoad": false,
                             "speech.synth": "espeak",
                             "speech.outputDevice": "Microsoft Sound Mapper",
                             "speech.symbolLevel": 300,
@@ -73,7 +72,6 @@ gpii.tests.windows.nvda = [
                             "speech.espeak.volume": 75,
                             "speech.espeak.pitch": 15,
                             "speech.espeak.rateBoost": true,
-                            "virtualBuffers.autoSayAllOnPageLoad": false,
                             "speech.symbolLevel": 300,
                             "speech.espeak.voice": "en\\en-wi",
                             "reviewCursor.followFocus": false,
@@ -114,8 +112,7 @@ gpii.tests.windows.nvda = [
                             "keyboard.speakTypedWords": true,
                             "speech.espeak.rateBoost": true,
                             "keyboard.speakTypedCharacters": false,
-                            "presentation.reportHelpBalloons": false,
-                            "virtualBuffers.autoSayAllOnPageLoad": false
+                            "presentation.reportHelpBalloons": false
                         },
                         "options": {
                             "filename": "${{environment}.APPDATA}\\nvda\\nvda.ini",


### PR DESCRIPTION
The common term readingUnit should not transform to NVDA's autoSayAllOnPageLoad. Activating NVDA's autoSayAllOnPageLoad when the preference set contains the common term readingUnit might be a fallback inferred be a matchmaker, but the settings are not equivalent.