### PR TITLE
NOJIRA: Removed the usage of inferred common terms from the flat matchmaker

### DIFF
--- a/gpii/node_modules/flatMatchMaker/src/FlatMatchMaker.js
+++ b/gpii/node_modules/flatMatchMaker/src/FlatMatchMaker.js
@@ -77,12 +77,12 @@
      */
     gpii.flatMatchMaker.addInferredCommon = function (preferences, inferred) {
         var togo = fluid.copy(preferences);
-        fluid.each(inferred, function (context, contextId) {
-            var tcont = togo.contexts[contextId];
-            fluid.each(context, function (settings) {
-                tcont.preferences = $.extend(true, settings, tcont.preferences);
-            });
-        });
+        // fluid.each(inferred, function (context, contextId) {
+        //     var tcont = togo.contexts[contextId];
+        //     fluid.each(context, function (settings) {
+        //         tcont.preferences = $.extend(true, settings, tcont.preferences);
+        //     });
+        // });
         return togo;
     };
 


### PR DESCRIPTION
this is a shitty, horrific hack, but will allow the pilots to work. It should NOT, EVER, be merged into master