### PR TITLE
GPII-1282: add simplifiedUiEnabled to OLB

### DIFF
--- a/testData/preferences/acceptanceTests/olb_Alicia_cmn.json
+++ b/testData/preferences/acceptanceTests/olb_Alicia_cmn.json
@@ -1,0 +1,16 @@
+{
+    "flat": {
+        "contexts": {
+            "gpii-default": {
+                "name": "Default preferences",
+                "preferences": {
+                    "http://registry.gpii.net/common/language": "en-GB",
+                    "http://registry.gpii.net/common/highContrastEnabled": true,
+                    "http://registry.gpii.net/common/highContrastTheme": "white-black",
+                    "http://registry.gpii.net/common/simplifiedUiEnabled": true
+                }
+            }
+        }
+    }
+}
+

--- a/testData/preferences/olb_Alicia_app.json
+++ b/testData/preferences/olb_Alicia_app.json
@@ -1,0 +1,18 @@
+{
+    "flat": {
+        "contexts": {
+            "gpii-default": {
+                "name": "Default preferences",
+                "preferences": {
+                    "http://registry.gpii.net/common/language": "en-GB",
+                    "http://registry.gpii.net/common/highContrastEnabled": true,
+                    "http://registry.gpii.net/common/highContrastTheme": "white-black",
+                    "http://registry.gpii.net/applications/eu.gpii.olb": {
+                        "simplifiedUiEnabled": true
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/testData/preferences/olb_Alicia_cmn.json
+++ b/testData/preferences/olb_Alicia_cmn.json
@@ -1,0 +1,16 @@
+{
+    "flat": {
+        "contexts": {
+            "gpii-default": {
+                "name": "Default preferences",
+                "preferences": {
+                    "http://registry.gpii.net/common/language": "en-GB",
+                    "http://registry.gpii.net/common/highContrastEnabled": true,
+                    "http://registry.gpii.net/common/highContrastTheme": "white-black",
+                    "http://registry.gpii.net/common/simplifiedUiEnabled": true
+                }
+            }
+        }
+    }
+}
+

--- a/testData/preferences/olb_preferences.md
+++ b/testData/preferences/olb_preferences.md
@@ -26,3 +26,13 @@ The following preference sets are used for testing and demonstrating the Online 
 ** user interface in German,
 ** German Sign Language by a human sign language interpreter.
 
+* `olb_Alicia_cmn.json`: preference set with only common terms for the following settings:
+** user interface in English (British English if available),
+** a white-on-black contrast theme,
+** a simplified User Interface.
+
+* `olb_Alicia_app.json`: preference set with a combination of common and application-specific common terms for the following settings:
+** user interface in English (British English if available),
+** a white-on-black contrast theme,
+** a simplified User Interface (application-specific).
+

--- a/testData/solutions/web.json
+++ b/testData/solutions/web.json
@@ -505,7 +505,8 @@
                     "interpreterType",
                     "pictogramEnabled",
                     "pictogramMode",
-                    "pictogramSymbolSet"
+                    "pictogramSymbolSet",
+                    "simplifiedUiEnabled"
                 ],
                 "capabilitiesTransformations": {
                     "language": "http://registry\\.gpii\\.net/common/language",
@@ -602,7 +603,8 @@
                             }
                         }
                     },
-                    "pictogramsEnabled": "http://registry\\.gpii\\.net/common/pictogramsEnabled"
+                    "pictogramsEnabled": "http://registry\\.gpii\\.net/common/pictogramsEnabled",
+                    "simplifiedUiEnabled": "http://registry\\.gpii\\.net/common/simplifiedUiEnabled"
                 }
             }
         }

--- a/tests/platform/cloud/AcceptanceTests_olb.js
+++ b/tests/platform/cloud/AcceptanceTests_olb.js
@@ -97,6 +97,19 @@ var testDefs = [
                 "interpreterType": "avatar"
             }
         }
+    },
+    {
+        name: "Test for Online Banking demonstrator (OLB) with Online Flow Manager: simplified UI.",
+        userToken: "olb_Alicia_cmn",
+        solutionId: "eu.gpii.olb",
+        expected: {
+            "eu.gpii.olb": {
+                "language": "en-GB",
+                "contrastTheme": "wb",
+                "signLanguage": "ils", // see https://issues.gpii.net/browse/GPII-1125 
+                "simplifiedUiEnabled": true
+            }
+        }
     }
 ];
 

--- a/tests/platform/cloud/AcceptanceTests_olb.txt
+++ b/tests/platform/cloud/AcceptanceTests_olb.txt
@@ -8,6 +8,7 @@ It relies on the following preference sets in ..\..\testData\preferences\accepta
 * olb_Lara.json
 * olb_QinKesheng.json
 * olb_applicationSpecific_01.json
+* olb_Alicia_cmn.json
 
 
 Requirements: 


### PR DESCRIPTION
This pull request contains the following:
* a new transformer for simplifiedUiEnabled,
* an acceptance test for the transformer for simplifiedUiEnabled,
* an NP set for the acceptance test,
* two NP sets to test simplifiedUiEnabled in the OLB: one using the common term (identical to the NP set for the acceptance test) and one using the application-specific term.