### PR TITLE
GPII-1286: Fixed the chrome and easit4all tests to properly run again…

### DIFF
--- a/gpii/node_modules/testing/src/CloudBased.js
+++ b/gpii/node_modules/testing/src/CloudBased.js
@@ -74,6 +74,8 @@ gpii.test.cloudBased.gpiiConfig = function (baseDir) {
 };
 
 gpii.test.cloudBased.buildTestFixture = function (testDef, baseDir) {
+    // Since we modify the testDef object, we make a copy of it to not screw up any other tests that
+    // might be sharing the same testDef
     testDef = fluid.copy(testDef);
     testDef.expect = 1;
     testDef.sequence = fluid.makeArray(testDef.sequence);

--- a/gpii/node_modules/testing/src/CloudBased.js
+++ b/gpii/node_modules/testing/src/CloudBased.js
@@ -74,6 +74,7 @@ gpii.test.cloudBased.gpiiConfig = function (baseDir) {
 };
 
 gpii.test.cloudBased.buildTestFixture = function (testDef, baseDir) {
+    testDef = fluid.copy(testDef);
     testDef.expect = 1;
     testDef.sequence = fluid.makeArray(testDef.sequence);
     testDef.gradeNames = fluid.makeArray(testDef.gradeNames);

--- a/gpii/node_modules/testing/src/CloudBasedOAuth2.js
+++ b/gpii/node_modules/testing/src/CloudBasedOAuth2.js
@@ -134,9 +134,9 @@ gpii.test.cloudBased.oauth2.verifyAuthorizeResponse = function (body, authorizeR
 
 gpii.test.cloudBased.oauth2.sendLoginRequest = function (loginRequest, options) {
     var formBody = {username: options.username, password: options.password};
-    
+
     formBody = gpii.test.cloudBased.oauth2.filter(formBody, options, "loginRequestForm");
-    
+
     loginRequest.send(gpii.test.stringifyFormBody(formBody));
 };
 
@@ -147,10 +147,10 @@ gpii.test.cloudBased.oauth2.sendDecisionRequest = function (decisionRequest, aut
         accept: true,
         selectedPreferences: fluid.copy(options.selectedPreferences)
     };
-    
+
     formBody = gpii.test.cloudBased.oauth2.filter(formBody, options, "decisionRequestForm");
     decisionRequest.formBody = formBody;
-    
+
     decisionRequest.send(gpii.test.stringifyFormBody(formBody));
 };
 
@@ -171,9 +171,9 @@ gpii.test.cloudBased.oauth2.sendAccessTokenRequest = function (accessTokenReques
         client_id: options.client_id,
         client_secret: options.client_secret
     };
-    
+
     formBody = gpii.test.cloudBased.oauth2.filter(formBody, options, "accessTokenForm");
-    
+
     accessTokenRequest.send(gpii.test.stringifyFormBody(formBody));
 };
 
@@ -334,7 +334,7 @@ fluid.defaults("gpii.test.cloudBased.oauth2.testCaseHolder", {
     }
 });
 
-// TODO: Find a scheme for identifying these elements by name rather than by 
+// TODO: Find a scheme for identifying these elements by name rather than by
 // number following implementation of FLUID-5506
 
 gpii.test.cloudBased.oauth2.mainSequence = [{ // 0
@@ -394,7 +394,7 @@ gpii.test.cloudBased.oauth2.mainSequence = [{ // 0
         listener: "gpii.test.cloudBased.oauth2.verifySecuredSettingsResponse",
         args: ["{arguments}.0", "{securedSettingsRequest}", "{testCaseHolder}.options.expected"]
     }];
-    
+
 gpii.test.cloudBased.oauth2.buildTestFixtureCommon = function (testDef, commonRec, baseDir) {
     testDef = $.extend(true, {}, testDef, commonRec);
 

--- a/tests/platform/cloud/AcceptanceTests_chrome.js
+++ b/tests/platform/cloud/AcceptanceTests_chrome.js
@@ -23,63 +23,7 @@ gpii.loadTestingSupport();
 
 fluid.registerNamespace("gpii.tests.cloud.chrome");
 
-gpii.tests.cloud.chrome.testDefs = [
-    { // TODO: This check should be a standard and automatic part of the "baseline acceptance tests" for every solution
-        name: "Acceptance test for empty preferences in Chrome",
-        userToken: "chrome_empty",
-        solutionId: "org.chrome.cloud4chrome",
-        expected: {
-            "org.chrome.cloud4chrome": {
-            }
-        }
-    },
-    {
-        name: "Acceptance test for background color change in Chrome",
-        userToken: "chrome_high_contrast",
-        solutionId: "org.chrome.cloud4chrome",
-        expected: {
-            "org.chrome.cloud4chrome": {
-                "fontSize": "medium",
-                "invertColours": false,
-                "magnifierEnabled": false,
-                "magnification": 1,
-                "highContrastTheme": "white-black",
-                "highContrastEnabled": true,
-                "screenReaderTTSEnabled": false
-            }
-        }
-    },
-    {
-        name: "Acceptance test for font size transformation in Chrome",
-        userToken: "chrome_font_size",
-        solutionId: "org.chrome.cloud4chrome",
-        expected: {
-            "org.chrome.cloud4chrome": {
-                "fontSize": "large",
-                "invertColours": false,
-                "magnifierEnabled": false,
-                "magnification": 1,
-                "highContrastEnabled": false,
-                "screenReaderTTSEnabled": false
-            }
-        }
-    },
-    {
-        name: "Acceptance test for magnification transformation in Chrome",
-        userToken: "chrome_magnification",
-        solutionId: "org.chrome.cloud4chrome",
-        expected: {
-            "org.chrome.cloud4chrome": {
-                "fontSize": "medium",
-                "invertColours": false,
-                "magnifierEnabled": true,
-                "magnification": 2,
-                "highContrastEnabled": false,
-                "screenReaderTTSEnabled": false
-            }
-        }
-    }
-];
+gpii.tests.cloud.chrome.testDefs = require("./AcceptanceTests_chrome_testDefs.json");
 
 // We would like to write something like this, but we lost Kettle's transformer chain when implementing
 // the GPII's test drivers:
@@ -90,6 +34,4 @@ gpii.tests.cloud.chrome.testDefs = [
 // }, ["gpii.test.cloudBased.testCaseHolder"],
 //     module, require, __dirname);
 
-if (require.main === module) {
-    module.exports = gpii.test.cloudBased.bootstrap(gpii.tests.cloud.chrome.testDefs, __dirname);
-}
+module.exports = gpii.test.cloudBased.bootstrap(gpii.tests.cloud.chrome.testDefs, __dirname);

--- a/tests/platform/cloud/AcceptanceTests_chrome.txt
+++ b/tests/platform/cloud/AcceptanceTests_chrome.txt
@@ -3,6 +3,8 @@ AcceptanceTests_chrome.js
 Description:
 This is an series of tests using the online flowmanager. 
 
+These tests use the testDefinitions from AcceptanceTests_chrome_testDefs.json (which are also shared with the chrome_oauth2 tests)
+
 Three N&P sets have been created in order to test the different transformations between the common terms and the clouc4all specific settings:
 * chrome_font_size tests the transformation from a numeric value in the common terms to an enumeration value ("medium", "large", "x-large")
 * chrome_magnification tests the transformation from a double value (1.2) to an integer (1, 2 or 3)

--- a/tests/platform/cloud/AcceptanceTests_chrome_oauth2.js
+++ b/tests/platform/cloud/AcceptanceTests_chrome_oauth2.js
@@ -16,6 +16,7 @@ var fluid = require("universal"),
     gpii = fluid.registerNamespace("gpii");
 
 fluid.registerNamespace("gpii.tests.cloud.oauth2.chrome");
+gpii.loadTestingSupport();
 
 require("./OAuth2AcceptanceDataStore.js");
 

--- a/tests/platform/cloud/AcceptanceTests_chrome_oauth2.js
+++ b/tests/platform/cloud/AcceptanceTests_chrome_oauth2.js
@@ -18,7 +18,6 @@ var fluid = require("universal"),
 fluid.registerNamespace("gpii.tests.cloud.oauth2.chrome");
 
 require("./OAuth2AcceptanceDataStore.js");
-require("./AcceptanceTests_chrome.js");
 
 gpii.tests.cloud.oauth2.chrome.common = {
     client_id: "org.chrome.cloud4chrome",
@@ -279,8 +278,8 @@ gpii.tests.cloud.oauth2.chrome.disruptions = [{
 }
 ];
 
-// gpii.test.cloudBased.oauth2.bootstrap(gpii.tests.cloud.chrome.testDefs, gpii.tests.cloud.oauth2.chrome.common, __dirname);
+var standardChromeTest = require("./AcceptanceTests_chrome_testDefs.json");
 
 // Test 1 is the first with nonempty preference set
-gpii.test.cloudBased.oauth2.bootstrapDisruptedTest(gpii.tests.cloud.chrome.testDefs[1], gpii.tests.cloud.oauth2.chrome.common,
+gpii.test.cloudBased.oauth2.bootstrapDisruptedTest(standardChromeTest[1], gpii.tests.cloud.oauth2.chrome.common,
     gpii.tests.cloud.oauth2.chrome.disruptions, __dirname);

--- a/tests/platform/cloud/AcceptanceTests_chrome_testDefs.json
+++ b/tests/platform/cloud/AcceptanceTests_chrome_testDefs.json
@@ -1,0 +1,57 @@
+[
+    {
+        "name": "Acceptance test for empty preferences in Chrome",
+        "userToken": "chrome_empty",
+        "solutionId": "org.chrome.cloud4chrome",
+        "expected": {
+            "org.chrome.cloud4chrome": {
+            }
+        }
+    },
+    {
+        "name": "Acceptance test for background color change in Chrome",
+        "userToken": "chrome_high_contrast",
+        "solutionId": "org.chrome.cloud4chrome",
+        "expected": {
+            "org.chrome.cloud4chrome": {
+                "fontSize": "medium",
+                "invertColours": false,
+                "magnifierEnabled": false,
+                "magnification": 1,
+                "highContrastTheme": "white-black",
+                "highContrastEnabled": true,
+                "screenReaderTTSEnabled": false
+            }
+        }
+    },
+    {
+        "name": "Acceptance test for font size transformation in Chrome",
+        "userToken": "chrome_font_size",
+        "solutionId": "org.chrome.cloud4chrome",
+        "expected": {
+            "org.chrome.cloud4chrome": {
+                "fontSize": "large",
+                "invertColours": false,
+                "magnifierEnabled": false,
+                "magnification": 1,
+                "highContrastEnabled": false,
+                "screenReaderTTSEnabled": false
+            }
+        }
+    },
+    {
+        "name": "Acceptance test for magnification transformation in Chrome",
+        "userToken": "chrome_magnification",
+        "solutionId": "org.chrome.cloud4chrome",
+        "expected": {
+            "org.chrome.cloud4chrome": {
+                "fontSize": "medium",
+                "invertColours": false,
+                "magnifierEnabled": true,
+                "magnification": 2,
+                "highContrastEnabled": false,
+                "screenReaderTTSEnabled": false
+            }
+        }
+    }
+]

--- a/tests/platform/cloud/AcceptanceTests_easit4all.js
+++ b/tests/platform/cloud/AcceptanceTests_easit4all.js
@@ -22,43 +22,6 @@ gpii.loadTestingSupport();
 
 fluid.registerNamespace("gpii.tests.cloud.easit4all");
 
-gpii.tests.cloud.easit4all.testDefs = [
-    {
-        name: "Acceptance test for font and background color transformation in Easit4all",
-        userToken: "easit4all_color",
-        solutionId: "com.bdigital.easit4all",
-        expected: {
-            "com.bdigital.easit4all": {
-                "fontSize": 10,
-                "magnification": 1,
-                "foregroundColor": "Yellow",
-                "backgroundColor": "Black"
-            }
-        }
-    },
-    {
-        name: "Acceptance test for font size transformation in Easit4all",
-        userToken: "easit4all_font_size",
-        solutionId: "com.bdigital.easit4all",
-        expected: {
-            "com.bdigital.easit4all": {
-                "fontSize": 20,
-                "fontFaceFontName": "Times New Roman"
-            }
-        }
-    },
-    {
-        name: "Acceptance test for magnification in Easit4all",
-        userToken: "easit4all_magnification",
-        solutionId: "com.bdigital.easit4all",
-        expected: {
-            "com.bdigital.easit4all": {
-                "magnification": 1 // TODO: This test is faulty since the transformation rule is faulty in the solutions registry - configured factor is actually 6
-            }
-        }
-    }
-];
+gpii.tests.cloud.easit4all.testDefs = require("./AcceptanceTests_easit4all_testDefs.json");
 
-if (require.main === module) {
-    module.exports = gpii.test.cloudBased.bootstrap(gpii.tests.cloud.easit4all.testDefs, __dirname);
-}
+module.exports = gpii.test.cloudBased.bootstrap(gpii.tests.cloud.easit4all.testDefs, __dirname);

--- a/tests/platform/cloud/AcceptanceTests_easit4all.txt
+++ b/tests/platform/cloud/AcceptanceTests_easit4all.txt
@@ -3,6 +3,8 @@ AcceptanceTests_easit4all.js
 Description:
 This is an series of tests using the online flowmanager. 
 
+These tests use the testDefinitions from AcceptanceTests_easit4all_testDefs.json (which are also shared with the easit4all_oauth2 tests)
+
 Three N&P sets have been created in order to test the different transformations between the common terms and the Easit4All specific settings:
 
 

--- a/tests/platform/cloud/AcceptanceTests_easit4all_oauth2_filtering.js
+++ b/tests/platform/cloud/AcceptanceTests_easit4all_oauth2_filtering.js
@@ -15,10 +15,11 @@ https://github.com/GPII/universal/blob/master/LICENSE.txt
 var fluid = require("universal"),
     gpii = fluid.registerNamespace("gpii");
 
+gpii.loadTestingSupport();
+
 fluid.registerNamespace("gpii.tests.cloud.oauth2.easit4all");
 
 require("./OAuth2AcceptanceDataStore.js");
-require("./AcceptanceTests_easit4all.js");
 
 gpii.tests.cloud.oauth2.easit4all.common = {
     client_id: "com.bdigital.easit4all",
@@ -60,5 +61,7 @@ gpii.tests.cloud.oauth2.easit4all.disruptions = [{
     }
 }];
 
-gpii.test.cloudBased.oauth2.bootstrapDisruptedTest(gpii.tests.cloud.easit4all.testDefs[0], gpii.tests.cloud.oauth2.easit4all.common,
+var standardEasit4allTest = require("./AcceptanceTests_easit4all_testDefs.json");
+
+gpii.test.cloudBased.oauth2.bootstrapDisruptedTest(standardEasit4allTest[0], gpii.tests.cloud.oauth2.easit4all.common,
     gpii.tests.cloud.oauth2.easit4all.disruptions, __dirname);

--- a/tests/platform/cloud/AcceptanceTests_easit4all_testDefs.json
+++ b/tests/platform/cloud/AcceptanceTests_easit4all_testDefs.json
@@ -1,0 +1,36 @@
+[
+    {
+        "name": "Acceptance test for font and background color transformation in Easit4all",
+        "userToken": "easit4all_color",
+        "solutionId": "com.bdigital.easit4all",
+        "expected": {
+            "com.bdigital.easit4all": {
+                "fontSize": 10,
+                "magnification": 1,
+                "foregroundColor": "Yellow",
+                "backgroundColor": "Black"
+            }
+        }
+    },
+    {
+        "name": "Acceptance test for font size transformation in Easit4all",
+        "userToken": "easit4all_font_size",
+        "solutionId": "com.bdigital.easit4all",
+        "expected": {
+            "com.bdigital.easit4all": {
+                "fontSize": 20,
+                "fontFaceFontName": "Times New Roman"
+            }
+        }
+    },
+    {
+        "name": "Acceptance test for magnification in Easit4all",
+        "userToken": "easit4all_magnification",
+        "solutionId": "com.bdigital.easit4all",
+        "expected": {
+            "com.bdigital.easit4all": {
+                "magnification": 1
+            }
+        }
+    }
+]


### PR DESCRIPTION
…. This involved separating out the testDefs into separate file and loading them from the standard and oauth tests.

This error can be seen by running the cloudbased chrome and easit tests individually - in which case they dont do any asserts... Once merged, they should be running properly again, both individually and as part of all-tests.js
