### PR TITLE
GPII-1310: Added gpii.deviceReporter.alwaysInstalled

### DIFF
--- a/gpii/node_modules/deviceReporter/src/DeviceReporter.js
+++ b/gpii/node_modules/deviceReporter/src/DeviceReporter.js
@@ -23,6 +23,7 @@ var fluid = require("infusion"),
 
 fluid.require("kettle", require);
 fluid.require("./DeviceGet.js", require);
+fluid.require("./DeviceReporterUtilities.js", require);
 
 fluid.defaults("gpii.deviceReporter.base", {
     gradeNames: ["kettle.app", "autoInit"],

--- a/gpii/node_modules/deviceReporter/src/DeviceReporterUtilities.js
+++ b/gpii/node_modules/deviceReporter/src/DeviceReporterUtilities.js
@@ -1,0 +1,33 @@
+/**
+ * GPII Device Reporter Utilities.
+ *
+ * Copyright 2015 Emergya
+ *
+ * Licensed under the New BSD license. You may not use this file except in
+ * compliance with this License.
+ *
+ * The research leading to these results has received funding from the European Union's
+ * Seventh Framework Programme (FP7/2007-2013)
+ * under grant agreement no. 289016.
+ *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/universal/blob/master/LICENSE.txt
+ */
+
+var fluid = require("infusion"),
+    gpii = fluid.registerNamespace("gpii");
+
+fluid.registerNamespace("gpii.deviceReporter");
+
+// Live Device Reporter mock function.
+// This is meant to be used by any OS built-in solution that needs to report
+// to the dynamic device reporter that they are always installed.
+//
+fluid.defaults("gpii.deviceReporter.alwaysInstalled", {
+    gradeNames: "fluid.function",
+    argumentMap: {}
+});
+
+gpii.deviceReporter.alwaysInstalled = function () {
+    return true;
+};

--- a/gpii/node_modules/testing/src/Integration.js
+++ b/gpii/node_modules/testing/src/Integration.js
@@ -431,7 +431,15 @@ gpii.test.integration.deviceReporterAware.populate = function (that) {
 };
 
 gpii.test.integration.deviceReporterAware.resolveName = function (that, name) {
-    return that.options.rootPath + "." + name;
+    var resolvedName;
+
+    if (name === "gpii.deviceReporter.alwaysInstalled") {
+        resolvedName = name;
+    } else {
+        resolvedName = that.options.rootPath + "." + name;
+    }
+
+    return resolvedName;
 };
 
 fluid.defaults("gpii.test.integration.deviceReporterAware.linux", {

--- a/testData/solutions/linux.json
+++ b/testData/solutions/linux.json
@@ -1524,6 +1524,11 @@
         "start": [
         ],
         "stop": [
+        ],
+        "isInstalled": [
+            {
+                "type": "gpii.deviceReporter.alwaysInstalled"
+            }
         ]
     }
 }

--- a/testData/solutions/win32.json
+++ b/testData/solutions/win32.json
@@ -1399,6 +1399,11 @@
         "start": [
         ],
         "stop": [
+        ],
+        "isInstalled": [
+            {
+                "type": "gpii.deviceReporter.alwaysInstalled"
+            }
         ]
     }
 }


### PR DESCRIPTION
This new function is meant to be used by solutions that are built-in and need to tell the live device reporter that they are always installed.
Also, we're taking account of this into our integration testing framework so we don't break tests.