### PR TITLE
GPII-1507: Adds changes required for automated browser and node-based tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ npm-debug.log
 
 Vagrantfile.local
 .vagrant/
+
+report.tap

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 npm-debug.log
 *.bak
+
+Vagrantfile.local
+.vagrant/

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ From the root of the `universal` folder, run the following command:
 
     npm test
 
+#### Running tests using a VM
+A VM can be automatically created using tools provided by the [Prosperity4All Quality Infrastructure](https://github.com/GPII/qi-development-environments/). Please ensure the [requirements](https://github.com/GPII/qi-development-environments/#requirements) have been met. The ``vagrant up`` command can then be used to provision a new VM.
+
 Usage
 -----
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,84 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+require 'yaml'
+
+ansible_vars = YAML.load_file("provisioning/vars.yml")
+
+app_name = ansible_vars["nodejs_app_name"]
+
+app_directory = ansible_vars["nodejs_app_install_dir"]
+
+app_start_script = ansible_vars["nodejs_app_start_script"]
+
+# Check for the existence of 'VM_HOST_TCP_PORT' or 'VM_GUEST_TCP_PORT'
+# environment variables. Otherwise if 'nodejs_app_tcp_port' is defined
+# in vars.yml then use that port. Failing that use defaults provided
+# in this file.
+host_tcp_port = ENV["VM_HOST_TCP_PORT"] || ansible_vars["nodejs_app_tcp_port"] || 8081
+guest_tcp_port = ansible_vars["nodejs_app_tcp_port"] || 8081
+
+# By default this VM will use 2 processor cores and 2GB of RAM. The 'VM_CPUS' and
+# "VM_RAM" environment variables can be used to change that behaviour.
+cpus = ENV["VM_CPUS"] || 2
+ram = ENV["VM_RAM"] || 2048
+
+Vagrant.configure(2) do |config|
+
+  config.vm.box = "inclusivedesign/fedora22"
+
+  # Your working directory will be synced to /home/vagrant/sync in the VM.
+  config.vm.synced_folder ".", "#{app_directory}"
+
+  # List additional directories to sync to the VM in your "Vagrantfile.local" file
+  # using the following format:
+  # config.vm.synced_folder "../path/on/your/host/os/your-project", "/home/vagrant/sync/your-project"
+
+  if File.exist? "Vagrantfile.local"
+    instance_eval File.read("Vagrantfile.local"), "Vagrantfile.local"
+  end
+
+  # Port forwarding takes place here. The 'guest' port is used inside the VM
+  # whereas the 'host' port is used by your host operating system.
+  config.vm.network "forwarded_port", guest: guest_tcp_port, host: host_tcp_port, protocol: "tcp",
+    auto_correct: true
+
+  # Port 19531 is needed so logs can be viewed using systemd-journal-gateway
+  config.vm.network "forwarded_port", guest: 19531, host: 19531, protocol: "tcp",
+    auto_correct: true
+
+  config.vm.hostname = app_name
+
+  config.vm.provider :virtualbox do |vm|
+    vm.customize ["modifyvm", :id, "--memory", ram]
+    vm.customize ["modifyvm", :id, "--cpus", cpus]
+    vm.customize ["modifyvm", :id, "--vram", "128"]
+    vm.customize ["modifyvm", :id, "--accelerate3d", "on"]
+    vm.customize ["modifyvm", :id, "--audio", "null", "--audiocontroller", "ac97"]
+    vm.customize ["modifyvm", :id, "--ioapic", "on"]
+    vm.customize ["setextradata", "global", "GUI/SuppressMessages", "all"]
+  end
+
+  config.vm.provision "shell", inline: <<-SHELL
+    sudo ansible-galaxy install -fr #{app_directory}/provisioning/requirements.yml
+    sudo PYTHONUNBUFFERED=1 ansible-playbook #{app_directory}/provisioning/playbook.yml --tags="install,configure"
+  SHELL
+
+  # Using config.vm.hostname to set the hostname on Fedora VMs seems to remove the string
+  # "localhost" from the first line of /etc/hosts. This script reinserts it if it's missing.
+  # https://github.com/mitchellh/vagrant/pull/6203
+  config.vm.provision "shell",
+    inline: "/usr/local/bin/edit-hosts.sh",
+    run: "always"
+
+  # http://serverfault.com/a/725051
+  #if app_start_script.to_s.strip.length != 0
+  #  config.vm.provision "shell", inline: "sudo systemctl restart #{app_name}.service",
+  #    run: "always"
+  #end
+
+  config.vm.provision "shell",
+    inline: "sudo systemctl restart systemd-journal-gatewayd.service",
+    run: "always"
+
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -70,14 +70,4 @@ Vagrant.configure(2) do |config|
     inline: "/usr/local/bin/edit-hosts.sh",
     run: "always"
 
-  # http://serverfault.com/a/725051
-  #if app_start_script.to_s.strip.length != 0
-  #  config.vm.provision "shell", inline: "sudo systemctl restart #{app_name}.service",
-  #    run: "always"
-  #end
-
-  #config.vm.provision "shell",
-  #  inline: "sudo systemctl restart systemd-journal-gatewayd.service",
-  #  run: "always"
-
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,10 +11,9 @@ app_directory = ansible_vars["nodejs_app_install_dir"]
 
 app_start_script = ansible_vars["nodejs_app_start_script"]
 
-# Check for the existence of 'VM_HOST_TCP_PORT' or 'VM_GUEST_TCP_PORT'
-# environment variables. Otherwise if 'nodejs_app_tcp_port' is defined
-# in vars.yml then use that port. Failing that use defaults provided
-# in this file.
+# Check for the existence of the 'VM_HOST_TCP_PORT' environment variable. If it
+# doesn't exist and 'nodejs_app_tcp_port' is defined in vars.yml then use that
+# port. Failing that use defaults provided in this file.
 host_tcp_port = ENV["VM_HOST_TCP_PORT"] || ansible_vars["nodejs_app_tcp_port"] || 8081
 guest_tcp_port = ansible_vars["nodejs_app_tcp_port"] || 8081
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,8 +44,8 @@ Vagrant.configure(2) do |config|
     auto_correct: true
 
   # Port 19531 is needed so logs can be viewed using systemd-journal-gateway
-  config.vm.network "forwarded_port", guest: 19531, host: 19531, protocol: "tcp",
-    auto_correct: true
+  #config.vm.network "forwarded_port", guest: 19531, host: 19531, protocol: "tcp",
+  #  auto_correct: true
 
   config.vm.hostname = app_name
 
@@ -77,8 +77,8 @@ Vagrant.configure(2) do |config|
   #    run: "always"
   #end
 
-  config.vm.provision "shell",
-    inline: "sudo systemctl restart systemd-journal-gatewayd.service",
-    run: "always"
+  #config.vm.provision "shell",
+  #  inline: "sudo systemctl restart systemd-journal-gatewayd.service",
+  #  run: "always"
 
 end

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -1,0 +1,11 @@
+---
+- hosts: localhost
+  user: root
+
+  vars_files:
+    - vars.yml
+
+  roles:
+    - facts
+    - nodejs
+

--- a/provisioning/requirements.yml
+++ b/provisioning/requirements.yml
@@ -1,0 +1,6 @@
+- src: https://github.com/idi-ops/ansible-facts
+  name: facts
+
+- src: https://github.com/idi-ops/ansible-nodejs
+  name: nodejs
+

--- a/provisioning/vars.yml
+++ b/provisioning/vars.yml
@@ -6,7 +6,7 @@ nodejs_app_name: universal
 
 nodejs_app_tcp_port: 8081
 
-# Node.js version required by application (supported versions: 0.10.36*, 0.10.40, 4.1.1)
+# Currently Node.js 0.10.* is required by Universal
 nodejs_version: 0.10.40
 
 # If a specific npm version is needed, specify it here

--- a/provisioning/vars.yml
+++ b/provisioning/vars.yml
@@ -4,6 +4,8 @@
 
 nodejs_app_name: universal
 
+nodejs_app_tcp_port: 8081
+
 # Node.js version required by application (supported versions: 0.10.36*, 0.10.40, 4.1.1)
 nodejs_version: 0.10.40
 

--- a/provisioning/vars.yml
+++ b/provisioning/vars.yml
@@ -4,21 +4,13 @@
 
 nodejs_app_name: universal
 
-nodejs_app_git_repo: https://github.com/gpii/universal.git
-
-nodejs_app_git_branch: master
-
 # Node.js version required by application (supported versions: 0.10.36*, 0.10.40, 4.1.1)
 nodejs_version: 0.10.40
 
 # If a specific npm version is needed, specify it here
 #nodejs_npm_version: 1.4.28
 
-nodejs_app_rpm_packages:
-  - gcc-c++
-
 nodejs_app_npm_packages:
-  - node-gyp
   - testem
 
 nodejs_app_commands:

--- a/provisioning/vars.yml
+++ b/provisioning/vars.yml
@@ -1,0 +1,33 @@
+---
+# Please refer to https://github.com/idi-ops/ansible-nodejs/blob/master/defaults/main.yml
+# for documentation related to these variables
+
+nodejs_app_name: universal
+
+nodejs_app_git_repo: https://github.com/gpii/universal.git
+
+nodejs_app_git_branch: master
+
+# Node.js version required by application (supported versions: 0.10.36*, 0.10.40, 4.1.1)
+nodejs_version: 0.10.40
+
+# If a specific npm version is needed, specify it here
+#nodejs_npm_version: 1.4.28
+
+nodejs_app_rpm_packages:
+  - gcc-c++
+
+nodejs_app_npm_packages:
+  - node-gyp
+  - testem
+
+nodejs_app_commands:
+  - npm install
+  - npm run dedupe-infusion
+
+nodejs_app_start_script: gpii.js
+
+nodejs_app_install_dir: /home/vagrant/sync/node_modules/universal
+
+nodejs_app_git_clone: false
+

--- a/tests/web/html/all-tests.html
+++ b/tests/web/html/all-tests.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="../../../node_modules/infusion/tests/lib/qunit/css/qunit.css" />
     <link rel="stylesheet" href="../../../node_modules/infusion/tests/lib/qunit/addons/composite/qunit-composite.css">
     <script src="../../../node_modules/infusion/tests/lib/qunit/js/qunit.js"></script>
+    <script src="/testem.js"></script>
     <script src="../../../node_modules/infusion/tests/lib/qunit/addons/composite/qunit-composite.js"></script>
     <script>
     QUnit.testSuites([

--- a/tests/web/testem_qi.json
+++ b/tests/web/testem_qi.json
@@ -1,0 +1,5 @@
+{
+    "test_page": "tests/web/html/all-tests.html",
+    "reporter": "tap",
+    "report_file": "report.tap"
+}


### PR DESCRIPTION
These changes add support for running automated browser tests (using [Testem](https://github.com/testem/testem)) and Node.js tests in a CI environment. The primary use case right now is the [GPII Jenkins server](https://ci.gpii.net/):

https://ci.gpii.net/job/universal-browser-tests/
https://ci.gpii.net/job/universal-browser-tests/tapResults.1.html