### PR TITLE
Update Docker build to use Ansible role

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM inclusivedesign/nodejs:0.10.40
+FROM inclusivedesign/nodejs:0.10.41
 
 WORKDIR /etc/ansible/playbooks
 

--- a/README.md
+++ b/README.md
@@ -88,19 +88,19 @@ The tests are run using the following command:
 Building Docker Images
 ----------------------
 
-A Dockerfile can be used to build a containerized version of GPII Universal, primarily for use by downstream containers running components such the Preferences Server and Flow Manager in standalone cloud configuration.
+The Dockerfile can be used to build a containerized version of GPII Universal, at this time primarily for use by downstream containers running components such the Preferences Server and Flow Manager in standalone cloud configuration.
 
 The following command can be used to build an image locally as long as it is run relative to the repository's Dockerfile:
 
-    docker build --rm -t gpii/universal:$(git rev-parse --short HEAD) .
+`docker build --rm -t gpii/universal:$(git rev-parse --short HEAD) .`
 
 That will use the Git repository's current abbreviated commit hash as a [Docker tag](https://docs.docker.com/reference/commandline/cli/#tag). If you would like to download the latest public Universal image you can use this command:    
 
-docker pull gpii/universal
+`docker pull gpii/universal`
 
 Or use the following command to download a particular image identified using a Git commit hash:
 
-docker pull gpii/universal:<first seven characters of a git commit hash>
+`docker pull gpii/universal:<first seven characters of a git commit hash>`
 
 Additional notes:
 

--- a/README.md
+++ b/README.md
@@ -85,24 +85,24 @@ The tests are run using the following command:
     node tests/ProductionConfigTests.js
 
 
-Deploying with Docker
----------------------
+Building Docker Images
+----------------------
 
-The [Docker Hub Automated Build service](http://docs.docker.com/docker-hub/builds/) is used to automatically build a [GPII Universal Docker image](https://registry.hub.docker.com/u/gpii/universal/). The Docker client can then be used to download updated images and launch containers.
+A Dockerfile can be used to build a containerized version of GPII Universal, primarily for use by downstream containers running components such the Preferences Server and Flow Manager in standalone cloud configuration.
 
 The following command can be used to build an image locally as long as it is run relative to the repository's Dockerfile:
 
     docker build --rm -t gpii/universal:$(git rev-parse --short HEAD) .
 
-That will use the Git repository's current abbreviated commit hash as a [Docker tag](https://docs.docker.com/reference/commandline/cli/#tag). If you would like to download the latest public Universal image you can use this command:
+That will use the Git repository's current abbreviated commit hash as a [Docker tag](https://docs.docker.com/reference/commandline/cli/#tag). If you would like to download the latest public Universal image you can use this command:    
 
-    docker pull gpii/universal
+docker pull gpii/universal
 
 Or use the following command to download a particular image identified using a Git commit hash:
 
-    docker pull gpii/universal:<first seven characters of a git commit hash>
+docker pull gpii/universal:<first seven characters of a git commit hash>
 
-GPII component images can then be built using the Universal image. Here are two examples:
+Additional notes:
 
-* https://github.com/gpii-ops/docker-preferences-server/
-* https://github.com/gpii-ops/docker-flow-manager/
+* The Docker images are built within the container context using the [same Ansible role](https://github.com/idi-ops/ansible-nodejs) used to provision VMs, to simplify the management of different environments.
+* Universal is installed to /opt/gpii/node_modules/universal to allow the test cases to resolve (they are run as part of the container build process to support building and deploying containers with CI)

--- a/README.md
+++ b/README.md
@@ -104,5 +104,5 @@ Or use the following command to download a particular image identified using a G
 
 Additional notes:
 
-* The Docker images are built within the container context using the [same Ansible role](https://github.com/idi-ops/ansible-nodejs) used to provision VMs, to simplify the management of different environments.
+* The Docker image is built within the container using the [same Ansible role](https://github.com/idi-ops/ansible-nodejs) used to provision VMs, to simplify the management of different environments.
 * Universal is installed to /opt/gpii/node_modules/universal to allow the test cases to resolve (they are run as part of the container build process to support building and deploying containers with CI)

--- a/README.md
+++ b/README.md
@@ -105,4 +105,5 @@ Or use the following command to download a particular image identified using a G
 Additional notes:
 
 * The Docker image is built within the container using the [same Ansible role](https://github.com/idi-ops/ansible-nodejs) used to provision VMs, to simplify the management of different environments.
-* Universal is installed to /opt/gpii/node_modules/universal to allow the test cases to resolve (they are run as part of the container build process to support building and deploying containers with CI)
+* Universal is installed to /opt/gpii/node_modules/universal to allow the node-based test cases to resolve. Regarding the tests:
+  * Currently, the node-based tests are always run when this container is built. If you would like to turn this off for local debugging or faster building, remove the `npm test` item in the `nodejs_app_commands` list in `provisioning/docker-vars.yml`

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,20 +3,20 @@
 
 require 'yaml'
 
-common_ansible_vars = YAML.load_file("provisioning/vars.yml")
-vagrant_ansible_vars = YAML.load_file("provisioning/vagrant-vars.yml")
+vars = YAML.load_file("provisioning/vars.yml")
+vagrant_vars = YAML.load_file("provisioning/vagrant-vars.yml")
 
-app_name = common_ansible_vars["nodejs_app_name"]
+app_name = vars["nodejs_app_name"]
 
-app_directory = vagrant_ansible_vars["nodejs_app_install_dir"]
+app_directory = vagrant_vars["nodejs_app_install_dir"]
 
-app_start_script = common_ansible_vars["nodejs_app_start_script"]
+app_start_script = vars["nodejs_app_start_script"]
 
 # Check for the existence of the 'VM_HOST_TCP_PORT' environment variable. If it
 # doesn't exist and 'nodejs_app_tcp_port' is defined in vars.yml then use that
 # port. Failing that use defaults provided in this file.
-host_tcp_port = ENV["VM_HOST_TCP_PORT"] || common_ansible_vars["nodejs_app_tcp_port"] || 8081
-guest_tcp_port = common_ansible_vars["nodejs_app_tcp_port"] || 8081
+host_tcp_port = ENV["VM_HOST_TCP_PORT"] || vars["nodejs_app_tcp_port"] || 8081
+guest_tcp_port = vars["nodejs_app_tcp_port"] || 8081
 
 # By default this VM will use 2 processor cores and 2GB of RAM. The 'VM_CPUS' and
 # "VM_RAM" environment variables can be used to change that behaviour.


### PR DESCRIPTION
This PR moves to building the Docker image for universal using the Ansible nodejs role, the same approach used for bringing up Vagrant environments by #426 

Following merge the same approach will be reused for building the downstream containers at:
- https://github.com/gpii-ops/docker-flow-manager
- https://github.com/gpii-ops/docker-preferences-server

@avtar should eyeball this to make sure he's good with how I've refactored the Vagrant approach to let Docker and Vagrant share common variables where appropriate.