### PR TITLE
GPII-1564 - Update version of Node.js due to security issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM inclusivedesign/nodejs:0.10.41
+FROM inclusivedesign/nodejs:0.10.42
 
 WORKDIR /etc/ansible/playbooks
 

--- a/provisioning/vars.yml
+++ b/provisioning/vars.yml
@@ -9,7 +9,7 @@ nodejs_app_name: universal
 nodejs_app_tcp_port: 8081
 
 # Currently Node.js 0.10.* is required by Universal
-nodejs_version: 0.10.40
+nodejs_version: 0.10.42
 
 # If a specific npm version is needed, specify it here
 #nodejs_npm_version: 1.4.28


### PR DESCRIPTION
New versions of Node.js have been released to address multiple security issues.

https://nodejs.org/en/blog/vulnerability/february-2016-security-releases

As a result, the Docker images and the Ansible Node.js role need to be updated.