### PR TITLE
GPII-1564 - Change node.js version required to 0.10.44

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM inclusivedesign/nodejs:0.10.42
+FROM inclusivedesign/nodejs:0.10.44
 
 WORKDIR /etc/ansible/playbooks
 

--- a/provisioning/vars.yml
+++ b/provisioning/vars.yml
@@ -9,7 +9,7 @@ nodejs_app_name: universal
 nodejs_app_tcp_port: 8081
 
 # Currently Node.js 0.10.* is required by Universal
-nodejs_version: 0.10.42
+nodejs_version: 0.10.44
 
 # If a specific npm version is needed, specify it here
 #nodejs_npm_version: 1.4.28


### PR DESCRIPTION
Changes:

https://nodejs.org/en/blog/release/v0.10.43
https://nodejs.org/en/blog/release/v0.10.44