### PR TITLE
Removed fixed version of base Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM inclusivedesign/nodejs:4.4.3
+FROM inclusivedesign/nodejs
 
 WORKDIR /etc/ansible/playbooks
 


### PR DESCRIPTION
The universal Docker container should take the latest version of the NodeJS container.