### PR TITLE
GPII-1318 - Comply with new LTS/Current split in supported Node.js versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM inclusivedesign/nodejs:4.4.3
+FROM inclusivedesign/nodejs:lts
 
 WORKDIR /etc/ansible/playbooks
 

--- a/provisioning/vars.yml
+++ b/provisioning/vars.yml
@@ -8,8 +8,11 @@ nodejs_app_name: universal
 
 nodejs_app_tcp_port: 8081
 
-# Currently Node.js 4.4.x is required by Universal
-nodejs_version: 4.4.3
+# Currently Node.js LTS (4.x or "Argon") is required by Universal
+nodejs_branch: lts
+
+# If a specific Node.js version is needed, specify it here. If not defined, defaults to the latest within the branch.
+#nodejs_version: 4.x.y
 
 # If a specific npm version is needed, specify it here
 #nodejs_npm_version: 2.15.1


### PR DESCRIPTION
Since GPII/universal#425 and idi-ops/ansible-nodejs#27 were merged, we have adopted a new way of tracking Node.js versions. Instead of specific versions, we are favoring the choice between LTS (currently 4.x) or Current (6.x) versions. The most significant benefit for GPII/universal is that we don't have to keep changing versions every time there is a new one with security fixes. Container images will get rebuild automatically and it should be transparent in the case of the LTS branch (bug and security fixes and as few breaking changes as possible).

Right now GPII/universal won't work with 0.10.x anymore and that Docker image has already been erased, so it's important to merge this. The changes should be very low-impact and have been tested as a consequence of the work done in GPII/universal#425.