### PR TITLE
GPII-1811: Updates Vagrant VM to Fedora 23.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,7 @@ ram = ENV["VM_RAM"] || 2048
 
 Vagrant.configure(2) do |config|
 
-  config.vm.box = "inclusivedesign/fedora22"
+  config.vm.box = "inclusivedesign/fedora23"
 
   # Your working directory will be synced to /home/vagrant/sync in the VM.
   config.vm.synced_folder ".", "#{app_directory}"


### PR DESCRIPTION
This pull request will hopefully save a few gigabytes on everyone's machine in the long run. It's a one-line fix.