### PR TITLE
GPII-1540: AT persists after sleep/lock/UAC

### DIFF
--- a/gpii/node_modules/contextManager/test/data/standardMMInput.json
+++ b/gpii/node_modules/contextManager/test/data/standardMMInput.json
@@ -122,7 +122,7 @@
             ],
             "stop": [
                 {
-                    "type": "gpii.windows.killProcessByName",
+                    "type": "gpii.windows.closeProcessByName",
                     "filename": "jfw.exe"
                 }
             ]
@@ -155,7 +155,7 @@
             ],
             "stop": [
                 {
-                    "type": "gpii.windows.killProcessByName",
+                    "type": "gpii.windows.closeProcessByName",
                     "filename": "osk.exe"
                 }
             ]
@@ -323,10 +323,10 @@
             ],
             "stop": [
                 {
-                    "type": "gpii.windows.killProcessByName",
+                    "type": "gpii.windows.closeProcessByName",
                     "filename": "nvda_service.exe"
                 },{
-                    "type": "gpii.windows.killProcessByName",
+                    "type": "gpii.windows.closeProcessByName",
                     "filename": "nvda.exe"
                 }
             ]

--- a/gpii/node_modules/matchMakerFramework/test/data/win32_full.json
+++ b/gpii/node_modules/matchMakerFramework/test/data/win32_full.json
@@ -63,7 +63,7 @@
         ],
         "stop": [
             {
-                "type": "gpii.windows.killProcessByName",
+                "type": "gpii.windows.closeProcessByName",
                 "filename": "jfw.exe"
             }
         ]
@@ -225,7 +225,7 @@
         ],
         "stop": [
             {
-                "type": "gpii.windows.killProcessByName",
+                "type": "gpii.windows.closeProcessByName",
                 "filename": "Magnify.exe"
             }
         ]
@@ -259,7 +259,7 @@
         ],
         "stop": [
             {
-                "type": "gpii.windows.killProcessByName",
+                "type": "gpii.windows.closeProcessByName",
                 "filename": "osk.exe"
             }
         ]
@@ -624,10 +624,10 @@
         ],
         "stop": [
             {
-                "type": "gpii.windows.killProcessByName",
+                "type": "gpii.windows.closeProcessByName",
                 "filename": "nvda_service.exe"
             },{
-                "type": "gpii.windows.killProcessByName",
+                "type": "gpii.windows.closeProcessByName",
                 "filename": "nvda.exe"
             }
         ]
@@ -662,7 +662,7 @@
         ],
         "stop": [
             {
-                    "type": "gpii.windows.killProcessByName",
+                    "type": "gpii.windows.closeProcessByName",
                     "filename": "firefox.exe"
             }
         ]
@@ -696,7 +696,7 @@
         ],
         "stop": [
             {
-                "type": "gpii.windows.killProcessByName",
+                "type": "gpii.windows.closeProcessByName",
                 "filename": "firefox.exe"
             }
         ]
@@ -730,7 +730,7 @@
         ],
         "stop": [
             {
-                "type": "gpii.windows.killProcessByName",
+                "type": "gpii.windows.closeProcessByName",
                 "filename": "firefox.exe"
             }
         ]
@@ -823,7 +823,7 @@
         ],
         "stop": [
             {
-                "type": "gpii.windows.killProcessByName",
+                "type": "gpii.windows.closeProcessByName",
                 "filename": "firefox.exe"
             }
         ],

--- a/testData/solutions/win32.json
+++ b/testData/solutions/win32.json
@@ -63,7 +63,7 @@
         ],
         "stop": [
             {
-                "type": "gpii.windows.killProcessByName",
+                "type": "gpii.windows.closeProcessByName",
                 "filename": "jfw.exe"
             }
         ],
@@ -244,7 +244,7 @@
         ],
         "stop": [
             {
-                "type": "gpii.windows.killProcessByName",
+                "type": "gpii.windows.closeProcessByName",
                 "filename": "Magnify.exe"
             }
         ],
@@ -283,7 +283,7 @@
         ],
         "stop": [
             {
-                "type": "gpii.windows.killProcessByName",
+                "type": "gpii.windows.closeProcessByName",
                 "filename": "osk.exe"
             }
         ],
@@ -654,10 +654,10 @@
         ],
         "stop": [
             {
-                "type": "gpii.windows.killProcessByName",
+                "type": "gpii.windows.closeProcessByName",
                 "filename": "nvda_service.exe"
             },{
-                "type": "gpii.windows.killProcessByName",
+                "type": "gpii.windows.closeProcessByName",
                 "filename": "nvda.exe"
             }
         ],
@@ -701,7 +701,7 @@
         ],
         "stop": [
             {
-                    "type": "gpii.windows.killProcessByName",
+                    "type": "gpii.windows.closeProcessByName",
                     "filename": "firefox.exe"
             }
         ],
@@ -740,7 +740,7 @@
         ],
         "stop": [
             {
-                "type": "gpii.windows.killProcessByName",
+                "type": "gpii.windows.closeProcessByName",
                 "filename": "firefox.exe"
             }
         ],
@@ -779,7 +779,7 @@
         ],
         "stop": [
             {
-                "type": "gpii.windows.killProcessByName",
+                "type": "gpii.windows.closeProcessByName",
                 "filename": "firefox.exe"
             }
         ],
@@ -877,7 +877,7 @@
         ],
         "stop": [
             {
-                "type": "gpii.windows.killProcessByName",
+                "type": "gpii.windows.closeProcessByName",
                 "filename": "firefox.exe"
             }
         ],


### PR DESCRIPTION
Replaced calls to killProcessByName with closeProcessByName.
This depends on https://github.com/GPII/windows/pull/86