### PR TITLE
GPII-1757: Windows 10 can not start keyboard

### DIFF
--- a/gpii/node_modules/contextManager/test/data/standardMMInput.json
+++ b/gpii/node_modules/contextManager/test/data/standardMMInput.json
@@ -150,7 +150,7 @@
             "start": [
                 {
                     "type": "gpii.launch.exec",
-                    "command": "${{environment}.SystemRoot}\\System32\\osk.exe"
+                    "command": "${{environment}.SystemRoot}\\explorer.exe ${{environment}.SystemRoot}\\System32\\osk.exe"
                 }
             ],
             "stop": [

--- a/gpii/node_modules/matchMakerFramework/test/data/win32_full.json
+++ b/gpii/node_modules/matchMakerFramework/test/data/win32_full.json
@@ -254,7 +254,7 @@
         "start": [
             {
                 "type": "gpii.launch.exec",
-                "command": "${{environment}.SystemRoot}\\System32\\osk.exe"
+                "command": "${{environment}.SystemRoot}\\explorer.exe ${{environment}.SystemRoot}\\System32\\osk.exe"
             }
         ],
         "stop": [

--- a/gpii/node_modules/matchMakerFramework/test/data/win32_full.json
+++ b/gpii/node_modules/matchMakerFramework/test/data/win32_full.json
@@ -220,7 +220,7 @@
         "start": [
             {
                 "type": "gpii.launch.exec",
-                "command": "${{environment}.SystemRoot}\\System32\\Magnify.exe"
+                "command": "${{environment}.SystemRoot}\\explorer.exe ${{environment}.SystemRoot}\\System32\\Magnify.exe"
             }
         ],
         "stop": [

--- a/testData/solutions/win32.json
+++ b/testData/solutions/win32.json
@@ -278,7 +278,7 @@
         "start": [
             {
                 "type": "gpii.launch.exec",
-                "command": "${{environment}.SystemRoot}\\System32\\osk.exe"
+                "command": "${{environment}.SystemRoot}\\explorer.exe ${{environment}.SystemRoot}\\System32\\osk.exe"
             }
         ],
         "stop": [

--- a/testData/solutions/win32.json
+++ b/testData/solutions/win32.json
@@ -239,7 +239,7 @@
         "start": [
             {
                 "type": "gpii.launch.exec",
-                "command": "${{environment}.SystemRoot}\\System32\\Magnify.exe"
+                "command": "${{environment}.SystemRoot}\\explorer.exe ${{environment}.SystemRoot}\\System32\\Magnify.exe"
             }
         ],
         "stop": [


### PR DESCRIPTION
Starting osk.exe via explorer, to ensure the native version is used.
This makes the On Screen Keyboard work on 64-bit Windows.