### PR TITLE
GPII-2008: Cursor size remains large after running acceptance tests on Windows

### DIFF
--- a/testData/solutions/win32.json
+++ b/testData/solutions/win32.json
@@ -1087,7 +1087,10 @@
             "settings.configure"
         ],
         "restore": [
-            "settings.configure"
+            "settings.configure",
+            {
+                "type": "gpii.windows.spiSettingsHandler.updateCursors"
+            }
         ],
         "start": [
             {


### PR DESCRIPTION
 Made the cursor also update after the settings have been restored.