### PR TITLE
GPII-2073: Persona Settings return on windows lock screen

### DIFF
--- a/testData/solutions/win32.json
+++ b/testData/solutions/win32.json
@@ -210,14 +210,16 @@
         ],
         "start": [
             {
-                "type": "gpii.launch.exec",
-                "command": "${{environment}.SystemRoot}\\explorer.exe ${{environment}.SystemRoot}\\System32\\Magnify.exe"
+                "type": "gpii.windows.enableRegisteredAt",
+                "name": "magnifierpane",
+                "enable": true
             }
         ],
         "stop": [
             {
-                "type": "gpii.windows.closeProcessByName",
-                "filename": "Magnify.exe"
+                "type": "gpii.windows.enableRegisteredAt",
+                "name": "magnifierpane",
+                "enable": false
             }
         ],
         "isInstalled": [
@@ -247,14 +249,16 @@
         },
         "start": [
             {
-                "type": "gpii.launch.exec",
-                "command": "${{environment}.SystemRoot}\\explorer.exe ${{environment}.SystemRoot}\\System32\\osk.exe"
+                "type": "gpii.windows.enableRegisteredAt",
+                "name": "osk",
+                "enable": true
             }
         ],
         "stop": [
             {
-                "type": "gpii.windows.closeProcessByName",
-                "filename": "osk.exe"
+                "type": "gpii.windows.enableRegisteredAt",
+                "name": "osk",
+                "enable": false
             }
         ],
         "isInstalled": [

--- a/testData/solutions/win32.json
+++ b/testData/solutions/win32.json
@@ -210,14 +210,14 @@
         ],
         "start": [
             {
-                "type": "gpii.windows.enableRegisteredAt",
+                "type": "gpii.windows.enableRegisteredAT",
                 "name": "magnifierpane",
                 "enable": true
             }
         ],
         "stop": [
             {
-                "type": "gpii.windows.enableRegisteredAt",
+                "type": "gpii.windows.enableRegisteredAT",
                 "name": "magnifierpane",
                 "enable": false
             }
@@ -249,14 +249,14 @@
         },
         "start": [
             {
-                "type": "gpii.windows.enableRegisteredAt",
+                "type": "gpii.windows.enableRegisteredAT",
                 "name": "osk",
                 "enable": true
             }
         ],
         "stop": [
             {
-                "type": "gpii.windows.enableRegisteredAt",
+                "type": "gpii.windows.enableRegisteredAT",
                 "name": "osk",
                 "enable": false
             }

--- a/testData/solutions/win32.json
+++ b/testData/solutions/win32.json
@@ -241,12 +241,30 @@
         },
         "settingsHandlers": {
             "configure": {
-                "type": "gpii.settingsHandlers.noSettings",
+                "type": "gpii.windows.registrySettingsHandler",
+                "options": {
+                    "hKey": "HKEY_CURRENT_USER",
+                    "path": "Software\\Microsoft\\Osk",
+                    "dataTypes": {
+                        "NavigationMode": "REG_DWORD"
+                    }
+                },
                 "capabilities": [
                     "http://registry\\.gpii\\.net/common/onScreenKeyboardEnabled"
-                ]
+                ],
+                "capabilitiesTransformations": {
+                    "NavigationMode": {
+                        "literalValue": 0
+                    }
+                }
             }
         },
+        "configure": [
+            "settings.configure"
+        ],
+        "restore": [
+            "settings.configure"
+        ],
         "start": [
             {
                 "type": "gpii.windows.enableRegisteredAT",


### PR DESCRIPTION
Updated the solutions registry to use "enableRegisteredAt" to start the built-in AT (osk and magnifier), as per https://github.com/GPII/windows/pull/98
