### PR TITLE
GPII-2085 - Switch node.js version from 'current' to 'lts'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM inclusivedesign/nodejs:current
+FROM inclusivedesign/nodejs:lts
 
 WORKDIR /etc/ansible/playbooks
 

--- a/provisioning/vars.yml
+++ b/provisioning/vars.yml
@@ -8,8 +8,8 @@ nodejs_app_name: universal
 
 nodejs_app_tcp_port: 8081
 
-# Currently Node.js LTS (4.x or "Argon") is required by Universal
-nodejs_branch: current
+# Currently Node.js 6.x LTS is required by Universal
+nodejs_branch: lts
 
 # If a specific Node.js version is needed, specify it here. If not defined, defaults to the latest within the branch.
 #nodejs_version: 4.x.y


### PR DESCRIPTION
It seems 'current' was being used and got committed to this repository as to make use of node.js 6.x (which wasn't released as a 'lts' release at the time).

This commit reverts that change since now node 6.x is a LTS release.

This should be a no-op.