### PR TITLE
GPII-1884: Update provisioning/requirements.yml of the GPII production VM

### DIFF
--- a/vagrant-configs/provisioning/requirements.yml
+++ b/vagrant-configs/provisioning/requirements.yml
@@ -7,13 +7,11 @@
 - src: https://github.com/idi-ops/ansible-nodejs
   name: nodejs
 
-- src: https://github.com/avtar/ansible-preferences-server
-  version: remotes/origin/GPII-1884
+- src: https://github.com/gpii-ops/ansible-preferences-server
   name: preferences-server
 
 - src: https://github.com/gpii-ops/ansible-preferences-server-data-loader
   name: preferences-server-data-loader
 
-- src: https://github.com/avtar/ansible-flow-manager
-  version: remotes/origin/GPII-1884
+- src: https://github.com/gpii-ops/ansible-flow-manager
   name: flow-manager


### PR DESCRIPTION
To use the master branches of gpii-ops/ansible-preferences-server and gpii-ops/ansible-flow-manager since the pull requests on those repos for fixing GPII-1884 (https://github.com/gpii-ops/ansible-preferences-server/pull/2 and https://github.com/gpii-ops/ansible-flow-manager/pull/3) have been merged.