### PR TITLE
GPII-252: Add support for highContrastTheme

### DIFF
--- a/testData/deviceReporter/installedSolutions.json
+++ b/testData/deviceReporter/installedSolutions.json
@@ -44,6 +44,10 @@
     },
 
     {
+        "id": "com.microsoft.windows.highContrastTheme"
+    },
+
+    {
         "id": "com.microsoft.windows.mouseTrailing"
     },
 

--- a/testData/solutions/win32.json5
+++ b/testData/solutions/win32.json5
@@ -952,6 +952,9 @@
                     },
                     "verifySettings": true
                 },
+                "supportedSettings": {
+                    "HighContrastOn": {}
+                },
                 "capabilities": [
                     "http://registry\\.gpii\\.net/common/highContrastEnabled"
                 ],
@@ -973,12 +976,45 @@
                 "inverseCapabilitiesTransformations": {
                     "http://registry\\.gpii\\.net/common/highContrastEnabled": "HighContrastOn.value"
                 }
+            },
+            "configureTheme": {
+                "type": "gpii.windows.registrySettingsHandler",
+                "options": {
+                    "hKey": "HKEY_CURRENT_USER",
+                    "path": "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes",
+                    "dataTypes": {
+                        "LastHighContrastTheme": "REG_SZ"
+                    }
+                },
+                "supportedSettings": {
+                    "LastHighContrastTheme": {}
+                },
+                "capabilities": [
+                    "http://registry\\.gpii\\.net/common/highContrastTheme"
+                ],
+                "capabilitiesTransformations": {
+                    "LastHighContrastTheme": {
+                        "transform": {
+                            "type": "fluid.transforms.valueMapper",
+                            "defaultInputPath": "http://registry\\.gpii\\.net/common/highContrastTheme",
+                            "match": {
+                                "black-white": "%SystemRoot%\\resources\\Ease of Access Themes\\hcwhite.theme",
+                                "white-black": "%SystemRoot%\\resources\\Ease of Access Themes\\hcblack.theme",
+                                "black-yellow": "%SystemRoot%\\resources\\Ease of Access Themes\\hc1.theme",
+                                "yellow-black": "%SystemRoot%\\resources\\Ease of Access Themes\\hc1.theme",
+                                "lime-black": "%SystemRoot%\\resources\\Ease of Access Themes\\hc2.theme"
+                            }
+                        }
+                    }
+                }
             }
         },
         "configure": [
+            "settings.configureTheme",
             "settings.configure"
         ],
         "restore": [
+            "settings.configureTheme",
             "settings.configure"
         ],
         "isInstalled": [


### PR DESCRIPTION
Just adds a registrySettingsHandler block to the com.microsoft.windows.highContrast block, which sets a registry value to the theme file. If highContrastEnabled is false, then nothing happens (but the registry value is still set)

Quick test: Log in as vladimir, and his white on black theme should be applied, rather than what was last used in Control Panel (default yellow on black).