### PR TITLE
GPII-2235: Ensures there's only one instance of GPII

### DIFF
--- a/gpii/node_modules/flowManager/src/FlowManager.js
+++ b/gpii/node_modules/flowManager/src/FlowManager.js
@@ -32,6 +32,7 @@ require("./UntrustedFlowManager.js");
 require("lifecycleManager");
 require("transformer");
 require("journal");
+require("singleInstance");
 
 fluid.defaults("gpii.flowManager", {
     gradeNames: ["kettle.app"],
@@ -118,6 +119,10 @@ fluid.defaults("gpii.flowManager.local", {
             method: "get",
             type: "gpii.flowManager.getUserToken.handler"
         }
+    },
+    listeners: {
+        "onCreate": "gpii.singleInstance.registerInstance",
+        "afterDestroy": "gpii.singleInstance.deregisterInstance"
     }
 });
 

--- a/gpii/node_modules/singleInstance/index.js
+++ b/gpii/node_modules/singleInstance/index.js
@@ -1,0 +1,25 @@
+/*
+ * Ensures there's only a single instance of GPII.
+ *
+ * Copyright 2017 Raising the Floor - International
+ *
+ * Licensed under the New BSD license. You may not use this file except in
+ * compliance with this License.
+ *
+ * The R&D leading to these results received funding from the
+ * Department of Education - Grant H421A150005 (GPII-APCP). However,
+ * these results do not necessarily represent the policy of the
+ * Department of Education, and you should not assume endorsement by the
+ * Federal Government.
+ *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/universal/blob/master/LICENSE.txt
+ */
+
+"use strict";
+
+var fluid = require("infusion");
+
+fluid.module.register("singleInstance", __dirname, require);
+
+require("./src/singleInstance.js");

--- a/gpii/node_modules/singleInstance/package.json
+++ b/gpii/node_modules/singleInstance/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "singleInstance",
+    "description": "Ensures the current GPII instance remains the only one running, if there isn't one already.",
+    "version": "0.3.0",
+    "author": "GPII",
+    "bugs": "http://issues.gpii.net/browse/GPII",
+    "homepage": "http://gpii.net/",
+    "dependencies": {},
+    "license" : "BSD-3-Clause",
+    "repository": "git://github.com/GPII/universal.git",
+    "main": "./index.js",
+    "engines": { "node" : ">=4.2.1" }
+}

--- a/gpii/node_modules/singleInstance/src/singleInstance.js
+++ b/gpii/node_modules/singleInstance/src/singleInstance.js
@@ -43,7 +43,7 @@ gpii.singleInstance.registerInstance = function (pidFile) {
     }
 
     var gpiiPid = gpii.singleInstance.checkInstance(pidFile);
-    if (gpiiPid !== null) {
+    if (gpiiPid === null) {
         // Write the pid, but fail if the file exists. The stale one was deleted, but there might be another
         // GPII instance just starting.
         fs.writeFileSync(pidFile, process.pid, { flag: "wx" });

--- a/gpii/node_modules/singleInstance/src/singleInstance.js
+++ b/gpii/node_modules/singleInstance/src/singleInstance.js
@@ -39,8 +39,7 @@ fluid.registerNamespace("gpii.singleInstance");
  */
 gpii.singleInstance.registerInstance = function (pidFile) {
     if (!pidFile) {
-        var settingsDirComponent = gpii.settingsDir();
-        pidFile = settingsDirComponent.getGpiiSettingsDir() + "/gpii.pid";
+        pidFile = gpii.singleInstance.getDefaultPidFile();
     }
 
     var gpiiPid = gpii.singleInstance.checkInstance(pidFile);
@@ -61,8 +60,7 @@ gpii.singleInstance.registerInstance = function (pidFile) {
  */
 gpii.singleInstance.checkInstance = function (pidFile) {
     if (!pidFile) {
-        var settingsDirComponent = gpii.settingsDir();
-        pidFile = settingsDirComponent.getGpiiSettingsDir() + "/gpii.pid";
+        pidFile = gpii.singleInstance.getDefaultPidFile();
     }
 
     var pid = null;
@@ -103,8 +101,7 @@ gpii.singleInstance.checkInstance = function (pidFile) {
  */
 gpii.singleInstance.deregisterInstance = function (pidFile) {
     if (!pidFile) {
-        var settingsDirComponent = gpii.settingsDir();
-        pidFile = settingsDirComponent.getGpiiSettingsDir() + "/gpii.pid";
+        pidFile = gpii.singleInstance.getDefaultPidFile();
     }
 
     var success = false;
@@ -115,4 +112,14 @@ gpii.singleInstance.deregisterInstance = function (pidFile) {
     }
 
     return success;
+};
+
+/**
+ * Get the default pid file path, "<settings dir>/gpii.pid".
+ */
+gpii.singleInstance.getDefaultPidFile = function () {
+    var settingsDirComponent = gpii.settingsDir();
+    var pidFile = settingsDirComponent.getGpiiSettingsDir() + "/gpii.pid";
+    settingsDirComponent.destroy();
+    return pidFile;
 };

--- a/gpii/node_modules/singleInstance/src/singleInstance.js
+++ b/gpii/node_modules/singleInstance/src/singleInstance.js
@@ -18,7 +18,7 @@
 
 "use strict";
 
-var fluid = require("universal");
+var fluid = require("infusion");
 var fs = require("fs");
 
 var gpii = fluid.registerNamespace("gpii");
@@ -38,7 +38,7 @@ fluid.registerNamespace("gpii.singleInstance");
  * @return {boolean} true if this instance is the only GPII instance.
  */
 gpii.singleInstance.registerInstance = function (pidFile) {
-    if (!pidFile) {
+    if (!pidFile || typeof(pidFile) !== "string") {
         pidFile = gpii.singleInstance.getDefaultPidFile();
     }
 
@@ -49,8 +49,17 @@ gpii.singleInstance.registerInstance = function (pidFile) {
         fs.writeFileSync(pidFile, process.pid, { flag: "wx" });
     }
 
-    return !gpiiPid || gpiiPid === process.pid;
+    var success = !gpiiPid || gpiiPid === process.pid;
+    if (!success) {
+        fluid.log(fluid.logLevel.WARN, "There's already an instance of GPII detected.");
+    }
+    return success;
 };
+
+fluid.defaults("gpii.singleInstance.registerInstance", {
+    gradeNames: "fluid.function"
+});
+
 
 /**
  * Checks for another GPII instance.
@@ -59,7 +68,7 @@ gpii.singleInstance.registerInstance = function (pidFile) {
  * @returns {number} non-zero PID of the other GPII process (including this process), or null if this is the only one.
  */
 gpii.singleInstance.checkInstance = function (pidFile) {
-    if (!pidFile) {
+    if (!pidFile || typeof(pidFile) !== "string") {
         pidFile = gpii.singleInstance.getDefaultPidFile();
     }
 
@@ -93,6 +102,10 @@ gpii.singleInstance.checkInstance = function (pidFile) {
     return pid || null;
 };
 
+fluid.defaults("gpii.singleInstance.checkInstance", {
+    gradeNames: "fluid.function"
+});
+
 /**
  * Prevents the current GPII instance from being the only one, called when the GPII process is being shutdown.
  *
@@ -100,7 +113,7 @@ gpii.singleInstance.checkInstance = function (pidFile) {
  * @return {Boolean} true if this instance was de-registered, false if it wasn't registered.
  */
 gpii.singleInstance.deregisterInstance = function (pidFile) {
-    if (!pidFile) {
+    if (!pidFile || typeof(pidFile) !== "string") {
         pidFile = gpii.singleInstance.getDefaultPidFile();
     }
 
@@ -113,6 +126,10 @@ gpii.singleInstance.deregisterInstance = function (pidFile) {
 
     return success;
 };
+
+fluid.defaults("gpii.singleInstance.deregisterInstance", {
+    gradeNames: "fluid.function"
+});
 
 /**
  * Get the default pid file path, "<settings dir>/gpii.pid".

--- a/gpii/node_modules/singleInstance/src/singleInstance.js
+++ b/gpii/node_modules/singleInstance/src/singleInstance.js
@@ -1,0 +1,118 @@
+/*
+ * Ensures there's only a single instance of GPII.
+ *
+ * Copyright 2017 Raising the Floor - International
+ *
+ * Licensed under the New BSD license. You may not use this file except in
+ * compliance with this License.
+ *
+ * The R&D leading to these results received funding from the
+ * Department of Education - Grant H421A150005 (GPII-APCP). However,
+ * these results do not necessarily represent the policy of the
+ * Department of Education, and you should not assume endorsement by the
+ * Federal Government.
+ *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/universal/blob/master/LICENSE.txt
+ */
+
+"use strict";
+
+var fluid = require("universal");
+var fs = require("fs");
+
+var gpii = fluid.registerNamespace("gpii");
+fluid.registerNamespace("gpii.singleInstance");
+
+/**
+ * Declares this instance of GPII to be the only instance, unless there's already one running.
+ *
+ * The "pid/lock file" method is used, where a file containing the pid of the current process is created. If it
+ * already exists, and the pid points to a running GPII instance, then the lock will fail.
+ *
+ * File IO is performed synchronously, ensuring the checks are made before GPII does anything else (eg, bind to a port).
+ *
+ * @todo More checks need to be made to ensure the pid is GPII, and not just another process.
+ *
+ * @param pidFile {String} [Optional] The path of the pid file. Default is "gpii.pid" in the settings directory.
+ * @return {boolean} true if this instance is the only GPII instance.
+ */
+gpii.singleInstance.registerInstance = function (pidFile) {
+    if (!pidFile) {
+        var settingsDirComponent = gpii.settingsDir();
+        pidFile = settingsDirComponent.getGpiiSettingsDir() + "/gpii.pid";
+    }
+
+    var gpiiPid = gpii.singleInstance.checkInstance(pidFile);
+    if (!gpiiPid) {
+        // Write the pid, but fail if the file exists. The stale one was deleted, but there might be another
+        // GPII instance just starting.
+        fs.writeFileSync(pidFile, process.pid, { flag: "wx" });
+    }
+
+    return !gpiiPid || gpiiPid === process.pid;
+};
+
+/**
+ * Checks for another GPII instance.
+ *
+ * @param pidFile {String} [Optional] The path of the pid file. Default is "gpii.pid" in the settings directory.
+ * @returns {number} the PID of the other GPII process (including this process), or null if this is the only one.
+ */
+gpii.singleInstance.checkInstance = function (pidFile) {
+    if (!pidFile) {
+        var settingsDirComponent = gpii.settingsDir();
+        pidFile = settingsDirComponent.getGpiiSettingsDir() + "/gpii.pid";
+    }
+
+    var pid = null;
+
+    try {
+        // Get the old pid from the lock file
+        var content = fs.readFileSync(pidFile, {encoding: "utf8"});
+        pid = parseInt(content);
+        if (pid && pid !== process.pid) {
+            try {
+                // Check if it's still running.
+                process.kill(pid, 0);
+                // No error means the process is running.
+                // TODO: Ensure the process really is GPII, and not just a re-use of the pid.
+            } catch (e) {
+                // Process isn't running (or permission denied, which suggests it's not GPII).
+                pid = null;
+            }
+        }
+
+        if (!pid) {
+            // Remove the pid file, as it's stale/invalid.
+            fs.unlinkSync(pidFile);
+        }
+    } catch (e) {
+        // The file doesn't exist.
+        pid = null;
+    }
+
+    return pid || null;
+};
+
+/**
+ * Prevents the current GPII instance from being the only one, called when the GPII process is being shutdown.
+ *
+ * @param pidFile
+ * @return {Boolean} true if this instance was de-registered, false if it wasn't registered.
+ */
+gpii.singleInstance.deregisterInstance = function (pidFile) {
+    if (!pidFile) {
+        var settingsDirComponent = gpii.settingsDir();
+        pidFile = settingsDirComponent.getGpiiSettingsDir() + "/gpii.pid";
+    }
+
+    var success = false;
+    var gpiiPid = gpii.singleInstance.checkInstance(pidFile);
+    if (gpiiPid === process.pid) {
+        success = true;
+        fs.unlinkSync(pidFile);
+    }
+
+    return success;
+};

--- a/gpii/node_modules/singleInstance/src/singleInstance.js
+++ b/gpii/node_modules/singleInstance/src/singleInstance.js
@@ -43,7 +43,7 @@ gpii.singleInstance.registerInstance = function (pidFile) {
     }
 
     var gpiiPid = gpii.singleInstance.checkInstance(pidFile);
-    if (!gpiiPid) {
+    if (gpiiPid !== null) {
         // Write the pid, but fail if the file exists. The stale one was deleted, but there might be another
         // GPII instance just starting.
         fs.writeFileSync(pidFile, process.pid, { flag: "wx" });
@@ -56,7 +56,7 @@ gpii.singleInstance.registerInstance = function (pidFile) {
  * Checks for another GPII instance.
  *
  * @param pidFile {String} [Optional] The path of the pid file. Default is "gpii.pid" in the settings directory.
- * @returns {number} the PID of the other GPII process (including this process), or null if this is the only one.
+ * @returns {number} non-zero PID of the other GPII process (including this process), or null if this is the only one.
  */
 gpii.singleInstance.checkInstance = function (pidFile) {
     if (!pidFile) {
@@ -69,6 +69,7 @@ gpii.singleInstance.checkInstance = function (pidFile) {
         // Get the old pid from the lock file
         var content = fs.readFileSync(pidFile, {encoding: "utf8"});
         pid = parseInt(content);
+        // A "0" PID will never be GPII (and process.kill will succeed on Linux).
         if (pid && pid !== process.pid) {
             try {
                 // Check if it's still running.
@@ -87,7 +88,6 @@ gpii.singleInstance.checkInstance = function (pidFile) {
         }
     } catch (e) {
         // The file doesn't exist.
-        pid = null;
     }
 
     return pid || null;

--- a/gpii/node_modules/singleInstance/test/SingleInstanceTests.js
+++ b/gpii/node_modules/singleInstance/test/SingleInstanceTests.js
@@ -1,0 +1,164 @@
+/*
+ * singleInstance Tests
+ *
+ * Copyright 2017 Raising the Floor - International
+ *
+ * Licensed under the New BSD license. You may not use this file except in
+ * compliance with this License.
+ *
+ * The R&D leading to these results received funding from the
+ * Department of Education - Grant H421A150005 (GPII-APCP). However,
+ * these results do not necessarily represent the policy of the
+ * Department of Education, and you should not assume endorsement by the
+ * Federal Government.
+ *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/universal/blob/master/LICENSE.txt
+ */
+
+"use strict";
+
+var fluid = require("universal"),
+    fs = require("fs"),
+    os = require("os"),
+    child_process = require("child_process");
+
+var jqUnit = fluid.require("node-jqunit");
+var gpii = fluid.registerNamespace("gpii");
+fluid.registerNamespace("gpii.tests.singleInstance");
+
+require("singleInstance");
+
+jqUnit.module("gpii.tests.singleInstance");
+
+jqUnit.test("Testing checkInstance, registerGpiiInstance, and deregisterInstance", function () {
+
+    var pidFile = os.tmpdir() + "/gpii-test-pid" + Date.now();
+
+    // Start another process (a cross-platform "sleep"), to test against a live pid.
+    var otherProcess = child_process.exec("node -e \"setTimeout(console.log, 5000)\"");
+
+    var tests = [
+        {
+            // no pidfile
+            testData: null,
+            expected: {
+                checkInstance: null,
+                registerInstance: true,
+                file: process.pid,
+                deregisterInstance: false
+            }
+        },
+        {
+            // junk content
+            testData: "not a pid",
+            expected: {
+                checkInstance: null,
+                registerInstance: true,
+                file: process.pid,
+                deregisterInstance: false
+            }
+        },
+        {
+            // non-running pid
+            testData: "-100",
+            expected: {
+                checkInstance: null,
+                registerInstance: true,
+                file: process.pid,
+                deregisterInstance: false
+            }
+        },
+        {
+            // this process
+            testData: process.pid,
+            expected: {
+                checkInstance: process.pid,
+                registerInstance: true,
+                file: process.pid,
+                deregisterInstance: true
+            }
+        },
+        {
+            // another process
+            testData: otherProcess.pid,
+            expected: {
+                checkInstance: otherProcess.pid,
+                // If the implementation was complete, then registerInstance should succeed because the test process
+                // isn't another GPII instance.
+                registerInstance: false,
+                file: otherProcess.pid,
+                deregisterInstance: false
+            }
+        }
+    ];
+
+    var funcs = [ "checkInstance", "registerInstance", "deregisterInstance" ];
+
+    var deletePidFile = function () {
+        try {
+            fs.unlinkSync(pidFile);
+        } catch (e) {
+            // Don't care if it failed, as long as it's gone.
+            if (fs.existsSync(pidFile)) {
+                throw e;
+            }
+        }
+    };
+
+    try {
+        while (funcs.length > 0) {
+            var func = funcs.shift();
+            for (var n = 0; n < tests.length; n++) {
+                var test = tests[n];
+                // Set the pid file.
+                if (test.testData === null) {
+                    deletePidFile();
+                } else {
+                    fs.writeFileSync(pidFile, test.testData);
+                }
+
+                // Call the function
+                var returnValue = gpii.singleInstance[func](pidFile);
+                jqUnit.assertEquals(func + " return #" + n, test.expected[func], returnValue);
+
+                if (func === "registerInstance") {
+                    // Check the new pid file
+                    var content = fs.readFileSync(pidFile, {encoding: "utf8"});
+                    var value = parseInt(content);
+                    jqUnit.assertEquals("registerInstance pidfile #" + n, test.expected.file, value);
+                } else if (func === "deregisterInstance") {
+                    if (returnValue) {
+                        var exists = fs.existsSync(pidFile);
+                        jqUnit.assertTrue("pidFile should not exist after a successful deregisterInstance", !exists);
+                    }
+                }
+
+                deletePidFile();
+            }
+        }
+    } finally {
+        deletePidFile();
+    }
+
+});
+
+jqUnit.test("Testing singleInstance end-to-end", function () {
+    var pidFile = os.tmpdir() + "/gpii-test-pid" + Date.now();
+
+    // perform an end-to-end test
+    var pid = gpii.singleInstance.checkInstance(pidFile);
+    jqUnit.assertEquals("Another instance should not be detected before registering", null, pid);
+
+    var registered = gpii.singleInstance.registerInstance(pidFile);
+    jqUnit.assertTrue("This instance should have been registered", registered);
+
+    pid = gpii.singleInstance.checkInstance(pidFile);
+    jqUnit.assertEquals("The current instance should be this one", process.pid, pid);
+
+    var deregistered = gpii.singleInstance.deregisterInstance(pidFile);
+    jqUnit.assertTrue("This instance should have been deregistered", deregistered);
+
+    pid = gpii.singleInstance.checkInstance(pidFile);
+    jqUnit.assertEquals("Another instance should not be detected after deregistering", null, pid);
+});

--- a/gpii/node_modules/singleInstance/test/SingleInstanceTests.js
+++ b/gpii/node_modules/singleInstance/test/SingleInstanceTests.js
@@ -31,69 +31,65 @@ require("singleInstance");
 
 jqUnit.module("gpii.tests.singleInstance");
 
+gpii.tests.singleInstance.testDefs = fluid.freezeRecursive([
+    {
+        // no pidfile
+        testData: null,
+        expected: {
+            checkInstance: null,
+            registerInstance: true,
+            file: "$processes.own.pid",
+            deregisterInstance: false
+        }
+    },
+    {
+        // junk content
+        testData: "not a pid",
+        expected: {
+            checkInstance: null,
+            registerInstance: true,
+            file: "$processes.own.pid",
+            deregisterInstance: false
+        }
+    },
+    {
+        // non-running pid
+        testData: "-100",
+        expected: {
+            checkInstance: null,
+            registerInstance: true,
+            file: "$processes.own.pid",
+            deregisterInstance: false
+        }
+    },
+    {
+        // this process
+        testData: "$processes.own.pid",
+        expected: {
+            checkInstance: "$processes.own.pid",
+            registerInstance: true,
+            file: "$processes.own.pid",
+            deregisterInstance: true
+        }
+    },
+    {
+        // another process
+        testData: "$processes.other.pid",
+        expected: {
+            checkInstance: "$processes.other.pid",
+            // If the implementation was complete, then registerInstance should succeed because the test process
+            // isn't another GPII instance.
+            registerInstance: false,
+            file: null,
+            deregisterInstance: false
+        }
+    }
+]);
+
 fluid.defaults("gpii.tests.singleInstance.testData", {
     gradeNames: "fluid.modelComponent",
     model: {
-        tests: [
-            {
-                // no pidfile
-                testData: null,
-                expected: {
-                    checkInstance: null,
-                    registerInstance: true,
-                    file: "$processes.own.pid",
-                    deregisterInstance: false
-                }
-            },
-            {
-                // junk content
-                testData: "not a pid",
-                expected: {
-                    checkInstance: null,
-                    registerInstance: true,
-                    file: "$processes.own.pid",
-                    deregisterInstance: false
-                }
-            },
-            {
-                // non-running pid
-                testData: "-100",
-                expected: {
-                    checkInstance: null,
-                    registerInstance: true,
-                    file: "$processes.own.pid",
-                    deregisterInstance: false
-                }
-            },
-            {
-                // this process
-                testData: "$processes.own.pid",
-                expected: {
-                    checkInstance: "$processes.own.pid",
-                    registerInstance: true,
-                    file: "$processes.own.pid",
-                    deregisterInstance: true
-                }
-            },
-            {
-                // another process
-                testData: "$processes.other.pid",
-                expected: {
-                    checkInstance: "$processes.other.pid",
-                    // If the implementation was complete, then registerInstance should succeed because the test process
-                    // isn't another GPII instance.
-                    registerInstance: false,
-                    file: null,
-                    deregisterInstance: false
-                }
-            }
-        ],
-        processes: {
-
-        }
-    },
-    invokers: {
-        getTests: "gpii.tests.singleInstance.getTests({that}.model)"
+        processes: {}
     }
 });
 
@@ -103,16 +99,14 @@ fluid.defaults("gpii.tests.singleInstance.testData", {
  * @param model {Object}
  * @return {Array} The test items.
  */
-gpii.tests.singleInstance.getTests = function (model) {
-    // Deeply handle "$lookup" values
-    var getRecursive = function (value) {
-        if (typeof(value) === "string") {
-            return value.charAt(0) === "$" ? fluid.get(model, value.substring(1)) : value;
-        } else {
-            return fluid.transform(value, getRecursive);
-        }
-    };
-    return getRecursive(model.tests);
+gpii.tests.singleInstance.resolveReferences = function (model, value) {
+    if (typeof(value) === "string") {
+        return value.charAt(0) === "$" ? fluid.get(model, value.substring(1)) : value;
+    } else {
+        return fluid.transform(value, function (obj) {
+            return gpii.tests.singleInstance.resolveReferences(model, obj);
+        });
+    }
 };
 
 gpii.tests.singleInstance.deletePidFile = function (pidFile) {
@@ -133,13 +127,14 @@ jqUnit.test("Testing checkInstance, registerGpiiInstance, and deregisterInstance
 
     // Start another process (a cross-platform "sleep"), to test against a live pid.
     var otherProcess = child_process.exec("node -e \"setTimeout(console.log, 5000)\"");
+
     var testData = gpii.tests.singleInstance.testData();
     testData.applier.change("processes", {
         own: process,
         other: otherProcess
     });
 
-    var tests = testData.getTests();
+    var tests = gpii.tests.singleInstance.resolveReferences(testData.model, gpii.tests.singleInstance.testDefs);
     var funcs = [ "checkInstance", "registerInstance", "deregisterInstance" ];
 
     try {

--- a/gpii/node_modules/singleInstance/test/SingleInstanceTests.js
+++ b/gpii/node_modules/singleInstance/test/SingleInstanceTests.js
@@ -181,6 +181,7 @@ jqUnit.test("Testing checkInstance, registerGpiiInstance, and deregisterInstance
         }
     } finally {
         gpii.tests.singleInstance.deletePidFile(pidFile);
+        testData.destroy();
     }
 
 });

--- a/gpii/node_modules/singleInstance/test/SingleInstanceTests.js
+++ b/gpii/node_modules/singleInstance/test/SingleInstanceTests.js
@@ -31,114 +31,156 @@ require("singleInstance");
 
 jqUnit.module("gpii.tests.singleInstance");
 
+fluid.defaults("gpii.tests.singleInstance.testData", {
+    gradeNames: "fluid.modelComponent",
+    model: {
+        tests: [
+            {
+                // no pidfile
+                testData: null,
+                expected: {
+                    checkInstance: null,
+                    registerInstance: true,
+                    file: "$processes.own.pid",
+                    deregisterInstance: false
+                }
+            },
+            {
+                // junk content
+                testData: "not a pid",
+                expected: {
+                    checkInstance: null,
+                    registerInstance: true,
+                    file: "$processes.own.pid",
+                    deregisterInstance: false
+                }
+            },
+            {
+                // non-running pid
+                testData: "-100",
+                expected: {
+                    checkInstance: null,
+                    registerInstance: true,
+                    file: "$processes.own.pid",
+                    deregisterInstance: false
+                }
+            },
+            {
+                // this process
+                testData: "$processes.own.pid",
+                expected: {
+                    checkInstance: "$processes.own.pid",
+                    registerInstance: true,
+                    file: "$processes.own.pid",
+                    deregisterInstance: true
+                }
+            },
+            {
+                // another process
+                testData: "$processes.other.pid",
+                expected: {
+                    checkInstance: "$processes.other.pid",
+                    // If the implementation was complete, then registerInstance should succeed because the test process
+                    // isn't another GPII instance.
+                    registerInstance: false,
+                    file: null,
+                    deregisterInstance: false
+                }
+            }
+        ],
+        processes: {
+
+        }
+    },
+    invokers: {
+        getTests: "gpii.tests.singleInstance.getTests({that}.model)"
+    }
+});
+
+/**
+ * Extracts the test items from model, performing look-ups from it ("$like.this")
+ *
+ * @param model {Object}
+ * @return {Array} The test items.
+ */
+gpii.tests.singleInstance.getTests = function (model) {
+    // Deeply handle "$lookup" values
+    var getRecursive = function (value) {
+        if (typeof(value) === "string") {
+            return value.charAt(0) === "$" ? fluid.get(model, value.substring(1)) : value;
+        } else {
+            return fluid.transform(value, getRecursive);
+        }
+    };
+    return getRecursive(model.tests);
+};
+
+gpii.tests.singleInstance.deletePidFile = function (pidFile) {
+    try {
+        fs.unlinkSync(pidFile);
+    } catch (e) {
+        // Don't care if it failed, as long as it's gone.
+        if (fs.existsSync(pidFile)) {
+            throw e;
+        }
+    }
+};
+
+
 jqUnit.test("Testing checkInstance, registerGpiiInstance, and deregisterInstance", function () {
 
     var pidFile = os.tmpdir() + "/gpii-test-pid" + Date.now();
 
     // Start another process (a cross-platform "sleep"), to test against a live pid.
     var otherProcess = child_process.exec("node -e \"setTimeout(console.log, 5000)\"");
+    var testData = gpii.tests.singleInstance.testData();
+    testData.applier.change("processes", {
+        own: process,
+        other: otherProcess
+    });
 
-    var tests = [
-        {
-            // no pidfile
-            testData: null,
-            expected: {
-                checkInstance: null,
-                registerInstance: true,
-                file: process.pid,
-                deregisterInstance: false
-            }
-        },
-        {
-            // junk content
-            testData: "not a pid",
-            expected: {
-                checkInstance: null,
-                registerInstance: true,
-                file: process.pid,
-                deregisterInstance: false
-            }
-        },
-        {
-            // non-running pid
-            testData: "-100",
-            expected: {
-                checkInstance: null,
-                registerInstance: true,
-                file: process.pid,
-                deregisterInstance: false
-            }
-        },
-        {
-            // this process
-            testData: process.pid,
-            expected: {
-                checkInstance: process.pid,
-                registerInstance: true,
-                file: process.pid,
-                deregisterInstance: true
-            }
-        },
-        {
-            // another process
-            testData: otherProcess.pid,
-            expected: {
-                checkInstance: otherProcess.pid,
-                // If the implementation was complete, then registerInstance should succeed because the test process
-                // isn't another GPII instance.
-                registerInstance: false,
-                file: otherProcess.pid,
-                deregisterInstance: false
-            }
-        }
-    ];
-
+    var tests = testData.getTests();
     var funcs = [ "checkInstance", "registerInstance", "deregisterInstance" ];
-
-    var deletePidFile = function () {
-        try {
-            fs.unlinkSync(pidFile);
-        } catch (e) {
-            // Don't care if it failed, as long as it's gone.
-            if (fs.existsSync(pidFile)) {
-                throw e;
-            }
-        }
-    };
 
     try {
         while (funcs.length > 0) {
             var func = funcs.shift();
             for (var n = 0; n < tests.length; n++) {
                 var test = tests[n];
+                var testName = func + " test " + n + ": ";
+
                 // Set the pid file.
                 if (test.testData === null) {
-                    deletePidFile();
+                    gpii.tests.singleInstance.deletePidFile(pidFile);
                 } else {
                     fs.writeFileSync(pidFile, test.testData);
                 }
 
                 // Call the function
                 var returnValue = gpii.singleInstance[func](pidFile);
-                jqUnit.assertEquals(func + " return #" + n, test.expected[func], returnValue);
+                jqUnit.assertEquals(testName + " return", test.expected[func], returnValue);
+
+                var exists = fs.existsSync(pidFile);
 
                 if (func === "registerInstance") {
-                    // Check the new pid file
-                    var content = fs.readFileSync(pidFile, {encoding: "utf8"});
-                    var value = parseInt(content);
-                    jqUnit.assertEquals("registerInstance pidfile #" + n, test.expected.file, value);
+                    if (test.expected.file !== null) {
+                        jqUnit.assertTrue(testName + "pid file should exist", exists);
+                        // Check the new pid file
+                        var content = fs.readFileSync(pidFile, {encoding: "utf8"});
+                        var value = parseInt(content);
+                        jqUnit.assertEquals(testName + "pidfile content", test.expected.file, value);
+                    }
                 } else if (func === "deregisterInstance") {
                     if (returnValue) {
-                        var exists = fs.existsSync(pidFile);
-                        jqUnit.assertTrue("pidFile should not exist after a successful deregisterInstance", !exists);
+                        jqUnit.assertTrue(testName + "pidFile should not exist after a successful deregisterInstance", !exists);
                     }
                 }
 
-                deletePidFile();
+                gpii.tests.singleInstance.deletePidFile(pidFile);
             }
         }
     } finally {
-        deletePidFile();
+        gpii.tests.singleInstance.deletePidFile(pidFile);
     }
 
 });

--- a/gpii/node_modules/singleInstance/test/SingleInstanceTests.js
+++ b/gpii/node_modules/singleInstance/test/SingleInstanceTests.js
@@ -96,7 +96,8 @@ fluid.defaults("gpii.tests.singleInstance.testData", {
 /**
  * Extracts the test items from model, performing look-ups from it ("$like.this")
  *
- * @param model {Object}
+ * @param model {Object} The object to resolve from.
+ * @param value {Object} The value (or values) to resolve.
  * @return {Array} The test items.
  */
 gpii.tests.singleInstance.resolveReferences = function (model, value) {
@@ -109,6 +110,11 @@ gpii.tests.singleInstance.resolveReferences = function (model, value) {
     }
 };
 
+/**
+ * Deletes the pid file, hiding errors if the file doesn't exist.
+ *
+ * @param pidFile {String} The pid file
+ */
 gpii.tests.singleInstance.deletePidFile = function (pidFile) {
     try {
         fs.unlinkSync(pidFile);
@@ -119,7 +125,6 @@ gpii.tests.singleInstance.deletePidFile = function (pidFile) {
         }
     }
 };
-
 
 jqUnit.test("Testing checkInstance, registerGpiiInstance, and deregisterInstance", function () {
 

--- a/tests/all-tests.js
+++ b/tests/all-tests.js
@@ -67,7 +67,8 @@ var testIncludes = [
     "../gpii/node_modules/preferencesServer/test/preferencesServerTests.js",
     "../gpii/node_modules/rawPreferencesServer/test/RawPreferencesTest.js",
     "../gpii/node_modules/ontologyHandler/test/node/OntologyHandlerTests.js",
-    "../gpii/node_modules/contextManager/test/ContextManagerTests.js"
+    "../gpii/node_modules/contextManager/test/ContextManagerTests.js",
+    "../gpii/node_modules/singleInstance/test/SingleInstanceTests.js"
 ];
 
 fluid.each(testIncludes, function (path) {


### PR DESCRIPTION
Uses a "pid file", where the process's pid is put into a file. If the file exists, and it points to a running process, then it assumes GPII is already running.

Determining if the running process is really GPII will depend on (or partially duplicate) the process reporter, so for now there's a risk of another process re-using an old GPII's PID.

