### PR TITLE
GPII-1716: Windows font-size

### DIFF
--- a/testData/deviceReporter/installedSolutions.json
+++ b/testData/deviceReporter/installedSolutions.json
@@ -48,6 +48,10 @@
     },
 
     {
+        "id": "com.microsoft.windows.fontSize"
+    },
+
+    {
         "id": "com.microsoft.windows.mouseTrailing"
     },
 

--- a/testData/solutions/win32.json5
+++ b/testData/solutions/win32.json5
@@ -1570,7 +1570,7 @@
                         "name": "NONCLIENTMETRICS"
                     },
                     "fWinIni": "SPIF_UPDATEINIFILE|SPIF_SENDCHANGE", // It won't update if these flags aren't set.
-                    "verifySettings": false // The next GET will be different to the last SET
+                    "verifySettings": false // The next GET will be different to the last SET.
                 },
                 "supportedSettings": {
                     "CaptionFont": {},
@@ -1588,7 +1588,8 @@
                 "capabilitiesTransformations": {
                     "CaptionFont": {
                         "transform": {
-                            "type": "fluid.transforms.value",
+                            "type": "fluid.transforms.linearScale",
+                            "factor": -1,
                             "inputPath": "http://registry\\.gpii\\.net/common/fontSize",
                             "outputPath": "value"
                         },
@@ -1598,7 +1599,8 @@
                     },
                     "SmallCaptionFont": {
                         "transform": {
-                            "type": "fluid.transforms.value",
+                            "type": "fluid.transforms.linearScale",
+                            "factor": -1,
                             "inputPath": "http://registry\\.gpii\\.net/common/fontSize",
                             "outputPath": "value"
                         },
@@ -1608,7 +1610,8 @@
                     },
                     "MenuFont": {
                         "transform": {
-                            "type": "fluid.transforms.value",
+                            "type": "fluid.transforms.linearScale",
+                            "factor": -1,
                             "inputPath": "http://registry\\.gpii\\.net/common/fontSize",
                             "outputPath": "value"
                         },
@@ -1618,7 +1621,8 @@
                     },
                     "StatusFont": {
                         "transform": {
-                            "type": "fluid.transforms.value",
+                            "type": "fluid.transforms.linearScale",
+                            "factor": -1,
                             "inputPath": "http://registry\\.gpii\\.net/common/fontSize",
                             "outputPath": "value"
                         },
@@ -1628,7 +1632,8 @@
                     },
                     "MessageFont": {
                         "transform": {
-                            "type": "fluid.transforms.value",
+                            "type": "fluid.transforms.linearScale",
+                            "factor": -1,
                             "inputPath": "http://registry\\.gpii\\.net/common/fontSize",
                             "outputPath": "value"
                         },
@@ -1636,23 +1641,36 @@
                             "literalValue": "pvParam.lfMessageFont.lfHeight"
                         }
                     },
-                    /* Set the pixel heights to 0 so they are calculated based on the font height */
+                    // The pixel heights will grow, but will not shrink back, so set the value to something so it will
+                    // be restored.
                     "CaptionHeight": {
-                        "literalValue": {
-                            "path": "pvParam.iCaptionHeight",
-                            "value": 0
+                        "transform": {
+                            "type": "fluid.transforms.literalValue",
+                            "inputPath": "pvParam.iCaptionHeight",
+                            "outputPath": "value"
+                        },
+                        "path": {
+                            "literalValue": "pvParam.iCaptionHeight"
                         }
                     },
                     "SmCaptionHeight": {
-                        "literalValue": {
-                            "path": "pvParam.iSmCaptionHeight",
-                            "value": 0
+                        "transform": {
+                            "type": "fluid.transforms.literalValue",
+                            "inputPath": "pvParam.iSmCaptionHeight",
+                            "outputPath": "value"
+                        },
+                        "path": {
+                            "literalValue": "pvParam.iSmCaptionHeight"
                         }
                     },
                     "MenuHeight": {
-                        "literalValue": {
-                            "path": "pvParam.iMenuHeight",
-                            "value": 0
+                        "transform": {
+                            "type": "fluid.transforms.literalValue",
+                            "inputPath": "pvParam.iMenuHeight",
+                            "outputPath": "value"
+                        },
+                        "path": {
+                            "literalValue": "pvParam.iMenuHeight"
                         }
                     }
                 }
@@ -1672,7 +1690,7 @@
                     "verifySettings": true
                 },
                 "supportedSettings": {
-                    "IconTitleFont": {},
+                    "IconTitleFont": {}
                 },
                 "capabilities": [
                     "http://registry\\.gpii\\.net/common/fontSize"
@@ -1680,7 +1698,8 @@
                 "capabilitiesTransformations": {
                     "IconTitleFont": {
                         "transform": {
-                            "type": "fluid.transforms.value",
+                            "type": "fluid.transforms.linearScale",
+                            "factor": -1,
                             "inputPath": "http://registry\\.gpii\\.net/common/fontSize",
                             "outputPath": "value"
                         },

--- a/testData/solutions/win32.json5
+++ b/testData/solutions/win32.json5
@@ -1548,6 +1548,164 @@
         ]
     },
 
+    "com.microsoft.windows.fontSize": {
+        "name": "Windows Font Size",
+        "contexts": {
+            "OS": [
+                {
+                    "id": "win32",
+                    "version": ">=5.0"
+                }
+            ]
+        },
+        "settingsHandlers": {
+            "configure.NonClientMetrics": {
+                "type": "gpii.windows.spiSettingsHandler",
+                "options": {
+                    "getAction": "SPI_GETNONCLIENTMETRICS",
+                    "setAction": "SPI_SETNONCLIENTMETRICS",
+                    "uiParam": "struct_size",
+                    "pvParam": {
+                        "type": "struct",
+                        "name": "NONCLIENTMETRICS"
+                    },
+                    "fWinIni": "SPIF_UPDATEINIFILE|SPIF_SENDCHANGE", // It won't update if these flags aren't set.
+                    "verifySettings": false // The next GET will be different to the last SET
+                },
+                "supportedSettings": {
+                    "CaptionFont": {},
+                    "SmallCaptionFont": {},
+                    "MenuFont": {},
+                    "StatusFont": {},
+                    "MessageFont": {},
+                    "CaptionHeight": {},
+                    "SmCaptionHeight": {},
+                    "MenuHeight": {}
+                },
+                "capabilities": [
+                    "http://registry\\.gpii\\.net/common/fontSize"
+                ],
+                "capabilitiesTransformations": {
+                    "CaptionFont": {
+                        "transform": {
+                            "type": "fluid.transforms.value",
+                            "inputPath": "http://registry\\.gpii\\.net/common/fontSize",
+                            "outputPath": "value"
+                        },
+                        "path": {
+                            "literalValue": "pvParam.lfCaptionFont.lfHeight"
+                        }
+                    },
+                    "SmallCaptionFont": {
+                        "transform": {
+                            "type": "fluid.transforms.value",
+                            "inputPath": "http://registry\\.gpii\\.net/common/fontSize",
+                            "outputPath": "value"
+                        },
+                        "path": {
+                            "literalValue": "pvParam.lfSmCaptionFont.lfHeight"
+                        }
+                    },
+                    "MenuFont": {
+                        "transform": {
+                            "type": "fluid.transforms.value",
+                            "inputPath": "http://registry\\.gpii\\.net/common/fontSize",
+                            "outputPath": "value"
+                        },
+                        "path": {
+                            "literalValue": "pvParam.lfMenuFont.lfHeight"
+                        }
+                    },
+                    "StatusFont": {
+                        "transform": {
+                            "type": "fluid.transforms.value",
+                            "inputPath": "http://registry\\.gpii\\.net/common/fontSize",
+                            "outputPath": "value"
+                        },
+                        "path": {
+                            "literalValue": "pvParam.lfStatusFont.lfHeight"
+                        }
+                    },
+                    "MessageFont": {
+                        "transform": {
+                            "type": "fluid.transforms.value",
+                            "inputPath": "http://registry\\.gpii\\.net/common/fontSize",
+                            "outputPath": "value"
+                        },
+                        "path": {
+                            "literalValue": "pvParam.lfMessageFont.lfHeight"
+                        }
+                    },
+                    /* Set the pixel heights to 0 so they are calculated based on the font height */
+                    "CaptionHeight": {
+                        "literalValue": {
+                            "path": "pvParam.iCaptionHeight",
+                            "value": 0
+                        }
+                    },
+                    "SmCaptionHeight": {
+                        "literalValue": {
+                            "path": "pvParam.iSmCaptionHeight",
+                            "value": 0
+                        }
+                    },
+                    "MenuHeight": {
+                        "literalValue": {
+                            "path": "pvParam.iMenuHeight",
+                            "value": 0
+                        }
+                    }
+                }
+            },
+            "configure.IconTitle": {
+                "type": "gpii.windows.spiSettingsHandler",
+                "options": {
+                    "getAction": "SPI_GETICONTITLELOGFONT",
+                    "setAction": "SPI_SETICONTITLELOGFONT",
+                    "uiParam": "struct_size",
+                    "pvParam": {
+                        "type": "struct",
+                        "name": "LOGFONT"
+                    },
+                    // If configure.NonClientMetrics is called after this one, then fWinIni doesn't need to be set.
+                    //"fWinIni": "SPIF_UPDATEINIFILE|SPIF_SENDCHANGE", // It won't update if these flags aren't set.
+                    "verifySettings": true
+                },
+                "supportedSettings": {
+                    "IconTitleFont": {},
+                },
+                "capabilities": [
+                    "http://registry\\.gpii\\.net/common/fontSize"
+                ],
+                "capabilitiesTransformations": {
+                    "IconTitleFont": {
+                        "transform": {
+                            "type": "fluid.transforms.value",
+                            "inputPath": "http://registry\\.gpii\\.net/common/fontSize",
+                            "outputPath": "value"
+                        },
+                        "path": {
+                            "literalValue": "pvParam.lfHeight"
+                        }
+                    }
+                }
+            }
+        },
+        "configure": [
+            "settings.configure.IconTitle",
+            "settings.configure.NonClientMetrics"
+        ],
+        "restore": [
+            "settings.configure.IconTitle",
+            "settings.configure.NonClientMetrics"
+        ],
+        "isInstalled": [
+            {
+                "type": "gpii.deviceReporter.alwaysInstalled"
+            }
+        ]
+    },
+
     "com.microsoft.windows.stickyKeys": {
         "name": "Windows StickyKeys",
         "contexts": {


### PR DESCRIPTION
Windows font-size support (via SPI, not the nicer DPI method).

FYI @javihernandez: If this is applied, it might change the way HST appears, because "sammy" increases the fontSize.

