### PR TITLE
GPII-2470 - Add env var needed to specify where Preferences server is located

### DIFF
--- a/gpii/configs/gpii.config.cloudBased.flowManager.production.json
+++ b/gpii/configs/gpii.config.cloudBased.flowManager.production.json
@@ -4,11 +4,6 @@
         "mainServerPort": 8082,
         "authDBServerPort": 5984,
         "distributeOptions": {
-            "preferencesDataSource.production.setUrl": {
-                "record": "https://preferences.gpii.net/preferences/%userToken",
-                 "target": "{that flowManager preferencesDataSource}.options.url",
-                 "priority": "after:preferencesDataSource.setUrl"
-            },
             "flowManager.production.matchMakers": {
                 "record": "http://localhost:8082",
                 "target": "{that flowManager}.options.matchMakers.default.url",

--- a/gpii/configs/gpii.config.cloudBased.production.json
+++ b/gpii/configs/gpii.config.cloudBased.production.json
@@ -1,11 +1,6 @@
 {
     "type": "gpii.config.cloudBased.flowManager.production",
     "options": {
-        "cloudBasedUrls": {
-            "preferences": "http://preferences.gpii.net/preferences/%userToken",
-            "deviceReporter": "",
-            "solutionsRegistry": "%universal/testData/solutions/"
-        },
         "matchMakers": {
             "default": {
                 "url": "http://localhost:8081"

--- a/gpii/node_modules/flowManager/configs/gpii.flowManager.config.production.json
+++ b/gpii/node_modules/flowManager/configs/gpii.flowManager.config.production.json
@@ -3,15 +3,20 @@
     "options": {
         "gradeNames": ["fluid.component"],
         "distributeOptions": {
-            "preferencesDataSource.setUrl": {
+            "preferencesDataSource.productionDataSource": {
                 "record": {
                     "type": "kettle.dataSource.URL",
                     "options": {
                         "url": "https://preferences.gpii.net/preferences/%userToken"
                     }
-                 },
-                 "target": "{that flowManager preferencesDataSource}"
-             }
+                },
+                "target": "{that flowManager preferencesDataSource}"
+            },
+            "preferencesDataSource.productionEnvUrl": {
+                "record": "@expand:kettle.resolvers.env(GPII_FLOWMANAGER_PREFERENCES_URL)",
+                "target": "{that flowManager preferencesDataSource}.options.url",
+                "priority": "after:preferencesDataSource.productionDataSource"
+            }
         }
     },
     "mergeConfigs": [


### PR DESCRIPTION
This is an initial change I would like to propose so Kasper's PR can be unlocked by pointing the Flow Manager at a different Preferences Server than the one hard coded into configuration files.

Please only merge this if this PR is accepted: https://github.com/fluid-project/kettle/pull/34 (KETTLE-62)