### PR TITLE
GPII-2151: Fixed lingering old-style `require`...

### DIFF
--- a/gpii/node_modules/singleInstance/test/SingleInstanceTests.js
+++ b/gpii/node_modules/singleInstance/test/SingleInstanceTests.js
@@ -18,7 +18,7 @@
 
 "use strict";
 
-var fluid = require("universal"),
+var fluid = require("infusion"),
     fs = require("fs"),
     os = require("os"),
     child_process = require("child_process");
@@ -26,6 +26,8 @@ var fluid = require("universal"),
 var jqUnit = fluid.require("node-jqunit");
 var gpii = fluid.registerNamespace("gpii");
 fluid.registerNamespace("gpii.tests.singleInstance");
+
+fluid.require("%universal");
 
 require("singleInstance");
 


### PR DESCRIPTION
Fixed a single test file that would cause tests to fail unless the repo was stored in an enclosing `node_modules` directory.  See [GPII-2151](https://issues.gpii.net/browse/GPII-2151) for details.