### PR TITLE
GPII-2411 - Add new env vars for Preferences Server and Flow Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,42 @@ If all is well, you will see a message like
 Note that this installation will not include any OS-specific features, but can be used to verify system function with
 basic preference sets which only start solutions which require filesystem-based configuration (XML, JSON or .INI files).
 
+Environment Variables
+---------------------
+
+Through the use of Kettle [resolvers](https://github.com/fluid-project/kettle/blob/master/docs/ConfigsAndApplications.md#referring-to-external-data-via-resolvers), some pre-defined configuration files offer the ability to read environment variables to change commonly used settings.
+
+#### Preferences Server
+
+The Preferences Server with the `gpii.config.cloudBased.flowManager.production` configuration uses the following variables:
+
+  * `GPII_PREFERENCES_LISTEN_PORT`: TCP port to listen on (default: 8081)
+  * `GPII_PREFERENCES_DATASOURCE_URL`: Location of CouchDB database (default: http://localhost:5984/preferences/%userToken)
+
+Example:
+
+```
+GPII_PREFERENCES_LISTEN_PORT=9090 \
+GPII_PREFERENCES_DATASOURCE_URL=https://localhost:5984/%userToken \
+NODE_ENV=gpii.config.cloudBased.flowManager.production \
+npm start
+```
+#### Flow Manager
+
+The Flow Manager with the `gpii.config.cloudBased.flowManager.production` configuration uses the following variables:
+
+  * `GPII_FLOWMANAGER_LISTEN_PORT`: TCP port to listen on (default: 8081)
+  * `GPII_FLOWMANAGER_PREFERENCES_URL`: Location of the Preferences Server (default: https://preferences.gpii.net/preferences/%userToken)
+
+Example:
+
+```
+GPII_FLOWMANAGER_LISTEN_PORT=9091 \
+GPII_FLOWMANAGER_PREFERENCES_URL=http://localhost:9090/preferences/%userToken \
+NODE_ENV=gpii.config.cloudBased.flowManager.production \
+npm start
+```
+
 Recovering From System Corruption Using the Journal
 ---------------------------------------------------
 

--- a/gpii/node_modules/flowManager/configs/gpii.flowManager.config.production.json
+++ b/gpii/node_modules/flowManager/configs/gpii.flowManager.config.production.json
@@ -16,6 +16,15 @@
                 "record": "@expand:kettle.resolvers.env(GPII_FLOWMANAGER_PREFERENCES_URL)",
                 "target": "{that flowManager preferencesDataSource}.options.url",
                 "priority": "after:preferencesDataSource.productionDataSource"
+            },
+            "distributePort.productionPort": {
+                "record": 8081,
+                "target": "{that kettle.server}.options.port"
+            },
+            "distributePort.productionEnvPort": {
+                "record": "@expand:kettle.resolvers.env(GPII_FLOWMANAGER_LISTEN_PORT)",
+                "target": "{that kettle.server}.options.port",
+                "priority": "after:distributePort.productionPort"
             }
         }
     },

--- a/gpii/node_modules/preferencesServer/configs/gpii.preferencesServer.config.production.json
+++ b/gpii/node_modules/preferencesServer/configs/gpii.preferencesServer.config.production.json
@@ -3,7 +3,7 @@
     "options": {
         "gradeNames": "fluid.component",
         "distributeOptions": {
-            "rawPreferencesDataSource": {
+            "rawPreferencesDataSource.productionDataSource": {
                 "record": {
                     "type": "kettle.dataSource.URL",
                     "options": {
@@ -13,13 +13,29 @@
                 },
                 "target": "{that preferencesServer rawPreferencesDataSource}"
             },
+            "rawPreferencesDataSource.productionEnvUrl": {
+                "record": {
+                    "type": "kettle.dataSource.URL",
+                    "options": {
+                        "gradeNames": "kettle.dataSource.CouchDB",
+                        "url": "@expand:kettle.resolvers.env(GPII_PREFERENCES_DATASOURCE_URL)"
+                    }
+                },
+                "target": "{that preferencesServer rawPreferencesDataSource}",
+                "priority": "after:rawPreferencesDataSource.productionDataSource"
+            },
             "logging": {
                  "record": true,
                  "target": "{that kettle.server}.options.logging"
             },
-            "distributePort": {
+            "distributePort.productionPort": {
                 "record": 8081,
                 "target": "{that kettle.server}.options.port"
+            },
+            "distributePort.productionEnvPort": {
+                "record": "@expand:kettle.resolvers.env(GPII_PREFERENCES_LISTEN_PORT)",
+                "target": "{that kettle.server}.options.port",
+                "priority": "after:distributePort.productionPort"
             }
         }
     },


### PR DESCRIPTION
# Environment variables:

 * GPII_PREFERENCES_LISTEN_PORT = TCP Port the Preferences Server should use
 * GPII_PREFERENCES_DATASOURCE_URL = Location of the CouchDB database
 * GPII_FLOWMANAGER_LISTEN_PORT = TCP Port the Flow Manager should use
 * GPII_FLOWMANAGER_PREFERENCES_URL = Location of Preferences Server (Added in GPII-2470)

# How to test:

## Preferences Server

```
$ GPII_PREFERENCES_LISTEN_PORT=9999 \
  GPII_PREFERENCES_DATASOURCE_URL=https://your-couchdb-server:5984/%userToken \
  NODE_ENV=gpii.config.cloudBased.flowManager.production npm start
$ curl http://localhost:999/preferences/carla
```

## Fow Manager

```
$ GPII_FLOWMANAGER_LISTEN_PORT=10001 \
  GPII_FLOWMANAGER_PREFERENCES_URL=https://preferences-staging.gpii.net/preferences/%userToken \
  NODE_ENV=gpii.config.cloudBased.flowManager.production npm start
```