### PR TITLE
GPII-442:  Fixed typo in argument list.

### DIFF
--- a/gpii/node_modules/processReporter/src/processesBridge.js
+++ b/gpii/node_modules/processReporter/src/processesBridge.js
@@ -75,13 +75,8 @@ fluid.defaults("gpii.processes", {
                              // command name (string)
         },
         // Context aware invokers.
-        getProcessList: {
-            funcName: "gpii.processes.get",
-            args: ["{that}.getPlatformProcessList", "{arguments}.0"]
-                                                     // optional string or numeric identifier of the process
-        },
-        getPlatformProcessList : {
-            funcName: "gpii.processes.getPlatformProcessList",
+        getProcessList : {
+            funcName: "gpii.processes.getProcessList",
             args: ["{arguments}.0"]
                    // optional string or numeric identifier of the process
         }
@@ -260,20 +255,6 @@ gpii.processes.initProcInfoNotRunning = function (that, command) {
 };
 
 /**
- * Get the current list of processes or a single processes based on an OS native
- * process inspector function.
- *
- * @param getPlatformProcessList {Function} - OS native function for getting the
- *                                            list of processes.
- * @param identifeer {Number} or {String} - Optional process id number or
- *                                          command name of the process.
- * @return {Array} - Returns a list of process information objects.
- */
-gpii.processes.get = function (getPlatformProcessList, identifier) {
-    return getPlatformProcessList(identifier);
-};
-
-/**
  * Default function for the base 'gpii.processes' grade to return an empty list
  * of process information objects.
  *
@@ -281,6 +262,6 @@ gpii.processes.get = function (getPlatformProcessList, identifier) {
  *                                          command name of the process.
  * @return {Array} - Returns an empty list.
  */
-gpii.processes.getPlatformProcessList = function (/* identifier */) {
+gpii.processes.getProcessList = function (/* identifier */) {
     return [];
 };

--- a/gpii/node_modules/processReporter/src/processesBridge.js
+++ b/gpii/node_modules/processReporter/src/processesBridge.js
@@ -77,7 +77,7 @@ fluid.defaults("gpii.processes", {
         // Contesxt aware invokers.
         getProcessList: {
             funcName: "gpii.processes.get",
-            args: ["{that}.getPlatformProcesssList", "{arguments).0"]
+            args: ["{that}.getPlatformProcesssList", "{arguments}.0"]
                                                      // optional string or numeric identifier of the process
         },
         getPlatformProcesssList : {

--- a/gpii/node_modules/processReporter/src/processesBridge.js
+++ b/gpii/node_modules/processReporter/src/processesBridge.js
@@ -74,14 +74,14 @@ fluid.defaults("gpii.processes", {
             args: ["{that}", "{arguments}.0"]
                              // command name (string)
         },
-        // Contesxt aware invokers.
+        // Context aware invokers.
         getProcessList: {
             funcName: "gpii.processes.get",
-            args: ["{that}.getPlatformProcesssList", "{arguments}.0"]
+            args: ["{that}.getPlatformProcessList", "{arguments}.0"]
                                                      // optional string or numeric identifier of the process
         },
-        getPlatformProcesssList : {
-            funcName: "gpii.processes.getPlatformProcesssList",
+        getPlatformProcessList : {
+            funcName: "gpii.processes.getPlatformProcessList",
             args: ["{arguments}.0"]
                    // optional string or numeric identifier of the process
         }
@@ -263,24 +263,24 @@ gpii.processes.initProcInfoNotRunning = function (that, command) {
  * Get the current list of processes or a single processes based on an OS native
  * process inspector function.
  *
- * @param getPlatformProcesssList {Function} - OS native function for getting the
+ * @param getPlatformProcessList {Function} - OS native function for getting the
  *                                            list of processes.
  * @param identifeer {Number} or {String} - Optional process id number or
- *                                          commadn name of the process.
+ *                                          command name of the process.
  * @return {Array} - Returns a list of process information objects.
  */
-gpii.processes.get = function (getPlatformProcesssList, identifier) {
-    return getPlatformProcesssList(identifier);
+gpii.processes.get = function (getPlatformProcessList, identifier) {
+    return getPlatformProcessList(identifier);
 };
 
 /**
  * Default function for the base 'gpii.processes' grade to return an empty list
  * of process information objects.
  *
- * @param identifeer {Number} or {String} - Optional process id number or
+ * @param identifier {Number} or {String} - Optional process id number or
  *                                          command name of the process.
  * @return {Array} - Returns an empty list.
  */
-gpii.processes.getPlatformProcesssList = function (/* identifier */) {
+gpii.processes.getPlatformProcessList = function (/* identifier */) {
     return [];
 };

--- a/gpii/node_modules/processReporter/test/web/js/ProcessesBridgeTests.js
+++ b/gpii/node_modules/processReporter/test/web/js/ProcessesBridgeTests.js
@@ -72,14 +72,14 @@ fluid.defaults("gpii.tests.processes.mock", {
         mockFirefox: gpii.tests.processes.mockFirefox
     },
     invokers: {
-        getPlatformProcessList: {
-            funcName: "gpii.tests.getPlatformProcessList",
+        getProcessList: {
+            funcName: "gpii.tests.getProcessList",
             args: ["{arguments}.0"]
         }
     }
 });
 
-gpii.tests.getPlatformProcessList = function (identifier) {
+gpii.tests.getProcessList = function (identifier) {
     var togo;
     var aProcInfo = null;
     if (identifier) {

--- a/gpii/node_modules/processReporter/test/web/js/ProcessesBridgeTests.js
+++ b/gpii/node_modules/processReporter/test/web/js/ProcessesBridgeTests.js
@@ -72,7 +72,7 @@ fluid.defaults("gpii.tests.processes.mock", {
         mockFirefox: gpii.tests.processes.mockFirefox
     },
     invokers: {
-        getPlatformProcesssList: {
+        getPlatformProcessList: {
             funcName: "gpii.tests.getPlatformProcessList",
             args: ["{arguments}.0"]
         }

--- a/gpii/node_modules/processReporter/test/web/js/ProcessesBridgeTests.js
+++ b/gpii/node_modules/processReporter/test/web/js/ProcessesBridgeTests.js
@@ -80,16 +80,22 @@ fluid.defaults("gpii.tests.processes.mock", {
 });
 
 gpii.tests.getPlatformProcessList = function (identifier) {
-    var togo = gpii.tests.processes.mockProcessesList;
+    var togo;
+    var aProcInfo = null;
     if (identifier) {
-        togo = fluid.find(
+        aProcInfo = fluid.find(
             gpii.tests.processes.mockProcessesList,
             function (procInfo) {
                 if (procInfo.pid === identifier) {
                     return procInfo;
                 }
-            }, gpii.tests.processes.mockProcessesList
+            }, null
         );
+    }
+    if (aProcInfo) {
+        togo = [aProcInfo];
+    } else {
+        togo = gpii.tests.processes.mockProcessesList;
     }
     return togo;
 };


### PR DESCRIPTION
@amb26, @stegru I found two bugs that partly explain the lag in windows in looking up targeted processes in the bridge.  They both involve a mistyped `"{arguments}.0"` in an `"args"` declaration, one in universal; the other in windows

This pull fixes the universal code.
