### PR TITLE
GPII-2589: Updated snapsets with required application specific settings

### DIFF
--- a/testData/deviceReporter/installedSolutions.json
+++ b/testData/deviceReporter/installedSolutions.json
@@ -113,6 +113,10 @@
 
     {
         "id": "com.android.settings.system"
+    },
+
+    {
+        "id": "net.gpii.uioPlus"
     }
 
 ]

--- a/testData/preferences/snapset_1a.json
+++ b/testData/preferences/snapset_1a.json
@@ -7,7 +7,8 @@
                     "http://registry.gpii.net/applications/com.microsoft.windows.screenDPI": {
                         "screen-dpi": 1.25
                     },
-                    "http://registry.gpii.net/common/cursorSize": 1.0
+                    "http://registry.gpii.net/common/cursorSize": 1.0,
+                    "http://registry.gpii.net/common/supportTool": ["dictionary"]
                 }
             }
         }

--- a/testData/preferences/snapset_1b.json
+++ b/testData/preferences/snapset_1b.json
@@ -7,7 +7,8 @@
                     "http://registry.gpii.net/applications/com.microsoft.windows.screenDPI": {
                         "screen-dpi": 1.50
                     },
-                    "http://registry.gpii.net/common/cursorSize": 1.0
+                    "http://registry.gpii.net/common/cursorSize": 1.0,
+                    "http://registry.gpii.net/common/supportTool": ["dictionary"]
                 }
             }
         }

--- a/testData/preferences/snapset_1c.json
+++ b/testData/preferences/snapset_1c.json
@@ -7,7 +7,8 @@
                     "http://registry.gpii.net/applications/com.microsoft.windows.screenDPI": {
                         "screen-dpi": 1.75
                     },
-                    "http://registry.gpii.net/common/cursorSize": 1.0
+                    "http://registry.gpii.net/common/cursorSize": 1.0,
+                    "http://registry.gpii.net/common/supportTool": ["dictionary"]
                 }
             }
         }

--- a/testData/preferences/snapset_2a.json
+++ b/testData/preferences/snapset_2a.json
@@ -4,12 +4,20 @@
             "gpii-default": {
                 "name": "Default preferences",
                 "preferences": {
+                    "http://registry.gpii.net/common/cursorSize": 1.0,
                     "http://registry.gpii.net/applications/com.microsoft.windows.screenDPI": {
                         "screen-dpi": 1.25
                     },
-                    "http://registry.gpii.net/common/cursorSize": 1.0,
-                    "http://registry.gpii.net/common/highContrastEnabled": true,
-                    "http://registry.gpii.net/common/highContrastTheme": "white-black"
+                    "http://registry.gpii.net/applications/com.microsoft.windows.highContrast": {
+                        "HighContrastOn":  {
+                            "path": "pvParam.dwFlags.HCF_HIGHCONTRASTON",
+                            "value": true
+                        },
+                        "LastHighContrastTheme": "%SystemRoot%\\resources\\Ease of Access Themes\\hcblack.theme"
+                    },
+                    "http://registry.gpii.net/applications/net.gpii.uioPlus": {
+                        "contrastTheme": "wb"
+                    }
                 }
             }
         }

--- a/testData/preferences/snapset_2b.json
+++ b/testData/preferences/snapset_2b.json
@@ -4,12 +4,20 @@
             "gpii-default": {
                 "name": "Default preferences",
                 "preferences": {
+                    "http://registry.gpii.net/common/cursorSize": 1.0,
                     "http://registry.gpii.net/applications/com.microsoft.windows.screenDPI": {
                         "screen-dpi": 1.50
                     },
-                    "http://registry.gpii.net/common/cursorSize": 1.0,
-                    "http://registry.gpii.net/common/highContrastEnabled": true,
-                    "http://registry.gpii.net/common/highContrastTheme": "white-black"
+                    "http://registry.gpii.net/applications/com.microsoft.windows.highContrast": {
+                        "HighContrastOn":  {
+                            "path": "pvParam.dwFlags.HCF_HIGHCONTRASTON",
+                            "value": true
+                        },
+                        "LastHighContrastTheme": "%SystemRoot%\\resources\\Ease of Access Themes\\hcblack.theme"
+                    },
+                    "http://registry.gpii.net/applications/net.gpii.uioPlus": {
+                        "contrastTheme": "wb"
+                    }
                 }
             }
         }

--- a/testData/preferences/snapset_2c.json
+++ b/testData/preferences/snapset_2c.json
@@ -4,12 +4,20 @@
             "gpii-default": {
                 "name": "Default preferences",
                 "preferences": {
+                    "http://registry.gpii.net/common/cursorSize": 1.0,
                     "http://registry.gpii.net/applications/com.microsoft.windows.screenDPI": {
                         "screen-dpi": 1.75
                     },
-                    "http://registry.gpii.net/common/cursorSize": 1.0,
-                    "http://registry.gpii.net/common/highContrastEnabled": true,
-                    "http://registry.gpii.net/common/highContrastTheme": "white-black"
+                    "http://registry.gpii.net/applications/com.microsoft.windows.highContrast": {
+                        "HighContrastOn":  {
+                            "path": "pvParam.dwFlags.HCF_HIGHCONTRASTON",
+                            "value": true
+                        },
+                        "LastHighContrastTheme": "%SystemRoot%\\resources\\Ease of Access Themes\\hcblack.theme"
+                    },
+                    "http://registry.gpii.net/applications/net.gpii.uioPlus": {
+                        "contrastTheme": "wb"
+                    }
                 }
             }
         }

--- a/testData/preferences/snapset_3.json
+++ b/testData/preferences/snapset_3.json
@@ -7,7 +7,9 @@
                     "http://registry.gpii.net/applications/com.microsoft.windows.screenDPI": {
                         "screen-dpi": 1.50
                     },
-                    "http://registry.gpii.net/common/cursorSize": 1.0
+                    "http://registry.gpii.net/common/cursorSize": 1.0,
+                    "http://registry.gpii.net/common/selfVoicingEnabled": true,
+                    "http://registry.gpii.net/common/supportTool": ["dictionary"]
                 }
             }
         }

--- a/testData/preferences/snapset_4a.json
+++ b/testData/preferences/snapset_4a.json
@@ -4,9 +4,10 @@
             "gpii-default": {
                 "name": "Default preferences",
                 "preferences": {
-                  "http://registry.gpii.net/common/magnifierEnabled": true,
-                  "http://registry.gpii.net/common/magnification": 2,
-                  "http://registry.gpii.net/common/magnifierPosition": "Lens"
+                    "http://registry.gpii.net/common/magnifierEnabled": true,
+                    "http://registry.gpii.net/common/magnification": 2,
+                    "http://registry.gpii.net/common/magnifierPosition": "Lens",
+                    "http://registry.gpii.net/common/supportTool": ["dictionary"]
                 }
             }
         }

--- a/testData/preferences/snapset_4b.json
+++ b/testData/preferences/snapset_4b.json
@@ -4,9 +4,10 @@
             "gpii-default": {
                 "name": "Default preferences",
                 "preferences": {
-                  "http://registry.gpii.net/common/magnifierEnabled": true,
-                  "http://registry.gpii.net/common/magnification": 4,
-                  "http://registry.gpii.net/common/magnifierPosition": "Lens"
+                    "http://registry.gpii.net/common/magnifierEnabled": true,
+                    "http://registry.gpii.net/common/magnification": 4,
+                    "http://registry.gpii.net/common/magnifierPosition": "Lens",
+                    "http://registry.gpii.net/common/supportTool": ["dictionary"]
                 }
             }
         }

--- a/testData/preferences/snapset_4c.json
+++ b/testData/preferences/snapset_4c.json
@@ -4,11 +4,13 @@
             "gpii-default": {
                 "name": "Default preferences",
                 "preferences": {
-                  "http://registry.gpii.net/common/magnifierEnabled": true,
-                  "http://registry.gpii.net/common/magnification": 2,
-                  "http://registry.gpii.net/common/magnifierPosition": "Lens",
-                  "http://registry.gpii.net/common/highContrastEnabled": true,
-                  "http://registry.gpii.net/common/highContrastTheme": "white-black"
+                    "http://registry.gpii.net/common/magnifierEnabled": true,
+                    "http://registry.gpii.net/common/magnification": 2,
+                    "http://registry.gpii.net/common/magnifierPosition": "Lens",
+                    "http://registry.gpii.net/common/supportTool": ["dictionary"],
+                    "http://registry.gpii.net/applications/com.microsoft.windows.screenDPI": {
+                        "screen-dpi": 1.75
+                    }
                 }
             }
         }

--- a/testData/preferences/snapset_4d.json
+++ b/testData/preferences/snapset_4d.json
@@ -4,12 +4,20 @@
             "gpii-default": {
                 "name": "Default preferences",
                 "preferences": {
-                  "http://registry.gpii.net/common/magnifierEnabled": true,
-                  "http://registry.gpii.net/common/magnification": 2,
-                  "http://registry.gpii.net/common/magnifierPosition": "Lens",
-                  "http://registry.gpii.net/applications/com.microsoft.windows.screenDPI": {
-                      "screen-dpi": 1.75
-                  }
+                    "http://registry.gpii.net/common/magnifierEnabled": true,
+                    "http://registry.gpii.net/common/magnification": 2,
+                    "http://registry.gpii.net/common/magnifierPosition": "Lens",
+                    "http://registry.gpii.net/common/supportTool": ["dictionary"],
+                    "http://registry.gpii.net/applications/com.microsoft.windows.highContrast": {
+                        "HighContrastOn":  {
+                            "path": "pvParam.dwFlags.HCF_HIGHCONTRASTON",
+                            "value": true
+                        },
+                        "LastHighContrastTheme": "%SystemRoot%\\resources\\Ease of Access Themes\\hcblack.theme"
+                    },
+                    "http://registry.gpii.net/applications/net.gpii.uioPlus": {
+                        "contrastTheme": "wb"
+                    }
                 }
             }
         }


### PR DESCRIPTION
Also, updated snapsets with settings for UIO+ chrome extension.

You can read more about the motivation of this pull request here, https://issues.gpii.net/browse/GPII-2589

First, we are fixing the problem of windows not applying high contrast themes. With this pull request, the high contrast must be applied when logging in with any "snapset_2" users.
Second, now that the support for the UIO+ chrome extension is in master and the extension seems to be in a pretty good shape, we are also updating the snapsets to ensure that the settings for UIO+ work too. Although the UIO+ chrome extension is not going to be tested in this first round of pilots, we would like this to happen pretty soon, and we need QA to start testing the snapsets with the UIO+ chrome extension as soon as possible.

In order to get ready to test this pull request, you need to use a windows vagrant box and edit the package.json to point to this universal branch (or hash).  Wipe out the "node_modules" folder and run npm install.
Also, you need to install the UIO+ chrome extension. In order to do that, you have to:
* Clone Justin's fork of gpii-chrome-extension
* Checkout into Justin's GPII-2424 branch
* Run npm install and npm install -g grunt-cli
* To build a dev version of the extension for you to use, run grunt buildDev, this will create a "build" folder. This "build" folder is the unpacked extension that can be installed in Google Chrome.
* Take that "build" folder and put it somewhere into your VM.
* Inside the VM, visit chrome://extensions in your browser. Alternatively, open the Chrome menu by clicking the icon to the far right of the Omnibox; The menu's icon is three horizontal bars. Select Extensions under the Tools menu to open Chrome's extension settings.
* Ensure that the Developer mode checkbox in the top right-hand corner is checked.
* Click Load unpacked extension to pop up a file-selection dialog.
* Navigate to the directory where you put the "build" folder and select it. This will install the extension.
* After that, you will be asked to install click2speech and google chrome dictionary. Install both of them.

Now everything should be ready. In order to ensure that the UIO+ extension works, restart the browser and browse into a web page of your choice.

Now you can key-in with the updated snapsets, the expected behavior for each snapset is described [here](https://github.com/GPII/universal/blob/master/testData/preferences/snapsets_apcp.md).