### PR TITLE
GPII-2621 - Add split node_modules workaround

### DIFF
--- a/vagrant-configs/Vagrantfile
+++ b/vagrant-configs/Vagrantfile
@@ -30,6 +30,13 @@ Vagrant.configure(2) do |config|
   # The main Universal root directory will be synced to /home/vagrant/sync in the VM.
   config.vm.synced_folder "..", "#{app_directory}"
 
+  # Mounts node_modules in /var/tmp to work around issues in the VirtualBox shared folders
+  config.vm.provision "shell", run: "always", inline: <<-SHELL
+    sudo mkdir -p /var/tmp/#{app_name}/node_modules #{app_directory}/node_modules
+    sudo chown vagrant:vagrant -R /var/tmp/#{app_name}/node_modules #{app_directory}/node_modules
+    sudo mount -o bind /var/tmp/#{app_name}/node_modules #{app_directory}/node_modules
+  SHELL
+
   # List additional directories to sync to the VM in your "Vagrantfile.local" file
   # using the following format:
   # config.vm.synced_folder "../path/on/your/host/os/your-project", "/home/vagrant/sync/your-project"


### PR DESCRIPTION
Adding code that is already in the main Vagrantfile to have the "split node_modules" solution so the node_modules outside the VM is separate from the one inside it.