### PR TITLE
GPII-2644: Added user friendly names in APCP snapsets

### DIFF
--- a/testData/preferences/snapset_1a.json
+++ b/testData/preferences/snapset_1a.json
@@ -1,5 +1,6 @@
 {
     "flat": {
+        "name": "Larger 125%",
         "contexts": {
             "gpii-default": {
                 "name": "Default preferences",

--- a/testData/preferences/snapset_1b.json
+++ b/testData/preferences/snapset_1b.json
@@ -1,5 +1,6 @@
 {
     "flat": {
+        "name": "Larger 150%",
         "contexts": {
             "gpii-default": {
                 "name": "Default preferences",

--- a/testData/preferences/snapset_1c.json
+++ b/testData/preferences/snapset_1c.json
@@ -1,5 +1,6 @@
 {
     "flat": {
+        "name": "Larger 175%",
         "contexts": {
             "gpii-default": {
                 "name": "Default preferences",

--- a/testData/preferences/snapset_2a.json
+++ b/testData/preferences/snapset_2a.json
@@ -1,5 +1,6 @@
 {
     "flat": {
+        "name": "Dark & Larger 125%",
         "contexts": {
             "gpii-default": {
                 "name": "Default preferences",

--- a/testData/preferences/snapset_2b.json
+++ b/testData/preferences/snapset_2b.json
@@ -1,5 +1,6 @@
 {
     "flat": {
+        "name": "Dark & Larger 150%",
         "contexts": {
             "gpii-default": {
                 "name": "Default preferences",

--- a/testData/preferences/snapset_2c.json
+++ b/testData/preferences/snapset_2c.json
@@ -1,5 +1,6 @@
 {
     "flat": {
+        "name": "Dark & Larger 175%",
         "contexts": {
             "gpii-default": {
                 "name": "Default preferences",

--- a/testData/preferences/snapset_3.json
+++ b/testData/preferences/snapset_3.json
@@ -1,5 +1,6 @@
 {
     "flat": {
+        "name": "Read To Me",
         "contexts": {
             "gpii-default": {
                 "name": "Default preferences",

--- a/testData/preferences/snapset_4a.json
+++ b/testData/preferences/snapset_4a.json
@@ -1,5 +1,6 @@
 {
     "flat": {
+        "name": "Magnifier 200%",
         "contexts": {
             "gpii-default": {
                 "name": "Default preferences",

--- a/testData/preferences/snapset_4b.json
+++ b/testData/preferences/snapset_4b.json
@@ -1,5 +1,6 @@
 {
     "flat": {
+        "name": "Magnifier 400%",
         "contexts": {
             "gpii-default": {
                 "name": "Default preferences",

--- a/testData/preferences/snapset_4c.json
+++ b/testData/preferences/snapset_4c.json
@@ -1,5 +1,6 @@
 {
     "flat": {
+        "name": "Large + Magnifier 200%",
         "contexts": {
             "gpii-default": {
                 "name": "Default preferences",

--- a/testData/preferences/snapset_4d.json
+++ b/testData/preferences/snapset_4d.json
@@ -1,5 +1,6 @@
 {
     "flat": {
+        "name": "Magnifier Dark 200%",
         "contexts": {
             "gpii-default": {
                 "name": "Default preferences",


### PR DESCRIPTION
Added user friendly names according to https://docs.google.com/document/d/1kaifumgrHacck2iyybESuMld_oDKlGtSAp0n0DqC-dk/edit