### PR TITLE
Add build status badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 GPII Universal
 ==============
 
+[![Build Status](https://ci.gpii.net/job/universal-tests/badge/icon)](https://ci.gpii.net/job/universal-tests/)
+
 The package contains cross-platform core components of the GPII personalization infrastructure. This repository should
 not be used directly, but in conjunction with one of the top-level GPII architecture-specific repositories.
 Additional documentation is available [on our wiki](http://wiki.gpii.net/w/Architecture).


### PR DESCRIPTION
The build of the master branch of Universal has been enabled. But Github doesn't have a place to show the build status of a particular branch, as the same way that it does in the PR conversation tab. This change adds a "badge" to the README.md with an image that indicates the status of the build of the master branch, in addition to a link to the log of the build.