### PR TITLE
GPII-2730: Added new snapset, solution registry entry and term for showcasing an 'OSRestart' setting

### DIFF
--- a/gpii/node_modules/preferencesServer/test/preferencesServerTests.js
+++ b/gpii/node_modules/preferencesServer/test/preferencesServerTests.js
@@ -607,6 +607,7 @@ gpii.tests.preferencesServer.get.fixtures = [
                             "http://registry\\.gpii\\.net/common/initDelay",
                             "http://registry\\.gpii\\.net/common/stickyKeys",
                             "http://registry\\.gpii\\.net/common/cursorSpeed",
+                            "http://registry\\.gpii\\.net/common/speechControl",
                             "http://registry\\.gpii\\.net/common/hapticFeedback",
                             "http://registry\\.gpii\\.net/common/slowKeysEnabled",
                             "http://registry\\.gpii\\.net/common/debounceEnabled",

--- a/testData/deviceReporter/installedSolutions.json
+++ b/testData/deviceReporter/installedSolutions.json
@@ -1,5 +1,9 @@
 [
     {
+        "id": "net.gpii.test.speechControl"
+    },
+
+    {
         "id": "org.gnome.desktop.interface"
     },
 

--- a/testData/ontologies/flat.json5
+++ b/testData/ontologies/flat.json5
@@ -305,6 +305,12 @@
             "description": "Whether to enable/disable audio description on videos",
             "type": "boolean",
             "default": "false"
+        },
+        "http://registry.gpii.net/common/speechControl": { // This is not currently supported by any real solutions, but rather used for user testing/demoing
+            "title": "Talk to the Computer",
+            "description": "Whether to enable/disable voice commands for computer",
+            "type": "boolean",
+            "default": "false"
         }
     }
 }

--- a/testData/ontologies/mappings/ISO24751-flat.json5
+++ b/testData/ontologies/mappings/ISO24751-flat.json5
@@ -56,6 +56,7 @@
     "http://registry\\.gpii\\.net/common/volume": "-provisional-general.-provisional-volume",
     "http://registry\\.gpii\\.net/common/language": "language",
     "http://registry\\.gpii\\.net/common/DPIScale": "display.screenEnhancement.-provisional-DPIScale",
+    "http://registry\\.gpii\\.net/common/speechControl": "control.-provisional-speechControl", // This is not currently supported by any real solutions, but rather used for user testing/demoing
     "": {
         "transform": {
             "type": "gpii.ontologyHandler.transforms.applicationISOToFlat",

--- a/testData/preferences/snapset_5.json
+++ b/testData/preferences/snapset_5.json
@@ -1,0 +1,15 @@
+{
+    "flat": {
+        "name": "Voice Control with Increased Size",
+        "contexts": {
+            "gpii-default": {
+                "name": "Default preferences",
+                "preferences": {
+                    "http://registry.gpii.net/common/DPIScale": 1.50,
+                    "http://registry.gpii.net/common/cursorSize": 1.0,
+                    "http://registry.gpii.net/common/speechControl": true
+                }
+            }
+        }
+    }
+}

--- a/testData/solutions/win32.json5
+++ b/testData/solutions/win32.json5
@@ -3204,5 +3204,36 @@
                 "type": "gpii.deviceReporter.alwaysInstalled"
             }
         ]
+    },
+    "net.gpii.test.speechControl": { // This solution does not exist in real life and has been added strictly for user testing/demoing
+        "name": "GPII Test solution for speech control of the computer",
+        "contexts": {
+            "OS": [
+                {
+                    "id": "win32",
+                    "version": ">=5.0"
+                }
+            ]
+        },
+        "settingsHandlers": {
+            "configure": {
+                "type": "gpii.settingsHandlers.noSettings",
+                "liveness": "OSRestart",
+                "capabilities": [
+                    "http://registry\\.gpii\\.net/common/speechControl"
+                ],
+                "supportedSettings": {}
+            }
+        },
+        "configure": [],
+        "restore": [],
+        "start": [],
+        "stop": [],
+        "isInstalled": [
+            {
+                "type": "gpii.deviceReporter.alwaysInstalled"
+            }
+        ],
+        "isRunning": []
     }
 }


### PR DESCRIPTION
Replacing https://github.com/GPII/universal/pull/568