### PR TITLE
GPII-2106: Workaround to close firefox when keying-out elaine

### DIFF
--- a/gpii/node_modules/settingsHandlers/src/NoSettingsHandler.js
+++ b/gpii/node_modules/settingsHandlers/src/NoSettingsHandler.js
@@ -20,4 +20,5 @@ var fluid = require("infusion"),
     settingsHandlers = fluid.registerNamespace("gpii.settingsHandlers");
 
 settingsHandlers.noSettings = fluid.identity;
+settingsHandlers.noSettings.set = fluid.identity;
 

--- a/testData/solutions/win32.json5
+++ b/testData/solutions/win32.json5
@@ -1762,10 +1762,11 @@
         ],
         "stop": [
             {
-                    "type": "gpii.windows.closeProcessByName",
-                    "filename": "firefox.exe"
+                "type": "gpii.windows.closeProcessByName",
+                "filename": "firefox.exe"
             }
         ],
+        "configure": [ "settings.configure" ],
         "isInstalled": [
             {
                 "type": "gpii.deviceReporter.alwaysInstalled"

--- a/testData/solutions/win32.json5
+++ b/testData/solutions/win32.json5
@@ -1766,6 +1766,12 @@
                 "filename": "firefox.exe"
             }
         ],
+        // Although there are no settings to deal with, we need to pass through
+        // the "configure" action in order to proceed with the "stop" directive
+        // when keying out. This is a current limitation of the system, you can
+        // check https://issues.gpii.net/browse/GPII-2106 and
+        // https://issues.gpii.net/browse/GPII-1235 for more detailed information.
+        //
         "configure": [ "settings.configure" ],
         "isInstalled": [
             {


### PR DESCRIPTION
This is a temporary workaround for https://issues.gpii.net/browse/GPII-2106 until https://github.com/GPII/universal/pull/507 gets in.