### PR TITLE
GPII-2897: Replaced 'fail' with 'reject' to actually reject a promise

### DIFF
--- a/gpii/node_modules/lifecycleManager/src/LifecycleManager.js
+++ b/gpii/node_modules/lifecycleManager/src/LifecycleManager.js
@@ -641,7 +641,7 @@ var gpii = fluid.registerNamespace("gpii");
         var session = that.getSession([userToken]);
         if (!session) {
             var failPromise = fluid.promise();
-            failPromise.fail("No session was found when attempting keyout");
+            failPromise.reject("No session was found when attempting keyout");
             return failPromise;
         }
         var restorePromise = gpii.lifecycleManager.restoreSystem(that, session, "stop");
@@ -684,7 +684,7 @@ var gpii = fluid.registerNamespace("gpii");
             lifecycleInstructions = finalPayload.activeConfiguration.lifecycleInstructions;
         if (that.sessionIndex[userToken]) {
             var failPromise = fluid.promise();
-            failPromise.fail("User already logged in when processing start item in queue. Aborting");
+            failPromise.reject("User already logged in when processing start item in queue. Aborting");
             return failPromise;
         }
         that.events.onSessionStart.fire("gpii.lifecycleManager.userSession", userToken);


### PR DESCRIPTION
https://issues.gpii.net/browse/GPII-2897
