### PR TITLE
 GPII-2946: "momentary", "maintained", and "hybrid" key token gestures.

### DIFF
--- a/gpii/node_modules/userListeners/src/listeners.js
+++ b/gpii/node_modules/userListeners/src/listeners.js
@@ -103,7 +103,7 @@ fluid.defaults("gpii.userListener", {
     members: {
         // True to auto-detect momentary or maintained key token usage, based on how soon it was removed. Otherwise,
         // use {that}.momentary.
-        detectMode: false,
+        detectMode: true,
         // Set to true to call proximityTriggered, otherwise login/logout (ignored if that.detectMode is true).
         momentary: false,
         // Override to provide the name of the listener.

--- a/gpii/node_modules/userListeners/src/listeners.js
+++ b/gpii/node_modules/userListeners/src/listeners.js
@@ -57,6 +57,10 @@ fluid.defaults("gpii.userListeners", {
 });
 
 // A user listener.
+// Listeners can have either "momentary", "maintained", or "hybrid" gesture modes:
+// - Momentary: token is presented to key-in, then presented again to key-out, like a caps-lock key. (momentary = true)
+// - Maintained: token is presented to key-in, then removed to key-out, like the shift key. (momentary = false)
+// - Hybrid mode detects what the user is trying to do, based on how soon the token is removed. (detectMode = true)
 fluid.defaults("gpii.userListener", {
     gradeNames: ["fluid.component"],
     events: {
@@ -86,11 +90,22 @@ fluid.defaults("gpii.userListener", {
                 "{that}",
                 "{arguments}.0" // The error.
             ]
+        },
+        callFlowManager: {
+            funcName: "gpii.userListeners.callFlowManager",
+            args: [
+                "{that}",
+                "{arguments}.0", // Token.
+                "{arguments}.1"  // Action ("login", "logout", or "proximityTriggered").
+            ]
         }
     },
     members: {
-        // Set to true to call proximityTriggered, otherwise login/logout.
-        proximity: false,
+        // True to auto-detect momentary or maintained key token usage, based on how soon it was removed. Otherwise,
+        // use {that}.momentary.
+        detectMode: false,
+        // Set to true to call proximityTriggered, otherwise login/logout (ignored if that.detectMode is true).
+        momentary: false,
         // Override to provide the name of the listener.
         listenerName: "no-name",
         // Number of failures
@@ -118,13 +133,16 @@ fluid.defaults("gpii.userListener", {
     },
 
     // Seconds (multiplied by failureCount) to wait before restarting.
-    failDelay: 10
+    failDelay: 10,
+    // If the token is removed before the timeout (seconds), then "momentary mode" is used. Otherwise, "maintained mode"
+    // is used.
+    detectModeTimeout: 4
 });
 
 /**
  * Handles the onTokenArrive event.
  *
- * It calls the "login" action for non-proximity devices, otherwise "proximityTriggered".
+ * It calls the "login" action for maintained key tokens, "proximityTriggered" for momentary.
  *
  * @param that {Component} An instance of gpii.userListener.
  * @param token {string} The token from the user listener.
@@ -132,14 +150,25 @@ fluid.defaults("gpii.userListener", {
 gpii.userListeners.tokenArrived = function (that, token) {
     fluid.log(that.listenerName + " token arrived: " + token);
 
-    var action = that.proximity ? "proximityTriggered" : "login";
-    request("http://localhost:8081/user/" + token + "/" + action);
+    var momentary = that.momentary;
+
+    if (that.detectMode) {
+        if (that.momentaryDetected) {
+            // A token has previously been presented (and quickly removed).
+            momentary = true;
+        }
+
+        that.arrivalTime = process.hrtime();
+        delete that.momentaryDetected;
+    }
+
+    that.callFlowManager(token, momentary ? "proximityTriggered" : "login");
 };
 
 /**
  * Handles the onTokenRemove event.
  *
- * It calls the "logout" action for non-proximity devices, otherwise it does nothing.
+ * It calls the "logout" action for maintained key tokens, "proximityTriggered" for momentary.
  *
  * @param that {Component} An instance of gpii.userListener.
  * @param token {string} The token from the user listener.
@@ -147,9 +176,32 @@ gpii.userListeners.tokenArrived = function (that, token) {
 gpii.userListeners.tokenRemoved = function (that, token) {
     fluid.log(that.listenerName + " token removed: " + token);
 
-    if (!that.proximity) {
-        request("http://localhost:8081/user/" + token + "/logout");
+    var momentary = that.momentary;
+
+    if (that.detectMode) {
+        // If the token was removed before the timeout, then ignore the removal (key-out will be performed when the next
+        // token is presented).
+        var time = process.hrtime(that.arrivalTime)[0];
+        that.momentaryDetected = time < that.options.detectModeTimeout;
+        momentary = that.momentaryDetected;
+        delete that.arrivalTime;
     }
+
+    // Don't logout for momentary
+    if (!momentary) {
+        that.callFlowManager(token, "logout");
+    }
+};
+
+/**
+ * Calls the flow manager with the user token and action.
+ *
+ * @param that {Component} An instance of gpii.userListener.
+ * @param token {string} The token from the user listener.
+ * @param action {String} Action to invoke ("login", "logout", or "proximityTriggered").
+ */
+gpii.userListeners.callFlowManager = function (that, token, action) {
+    request("http://localhost:8081/user/" + token + "/" + action);
 };
 
 /**

--- a/gpii/node_modules/userListeners/test/listenersTests.js
+++ b/gpii/node_modules/userListeners/test/listenersTests.js
@@ -1,0 +1,199 @@
+/*
+ * User listener tests
+ *
+ * Copyright 2017 Raising the Floor - International
+ *
+ * Licensed under the New BSD license. You may not use this file except in
+ * compliance with this License.
+ *
+ * The R&D leading to these results received funding from the
+ * Department of Education - Grant H421A150005 (GPII-APCP). However,
+ * these results do not necessarily represent the policy of the
+ * Department of Education, and you should not assume endorsement by the
+ * Federal Government.
+ *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/universal/blob/master/LICENSE.txt
+ */
+
+"use strict";
+var fluid = require("infusion");
+
+var jqUnit = fluid.require("node-jqunit");
+var gpii = fluid.registerNamespace("gpii");
+fluid.registerNamespace("gpii.tests.userListener");
+
+require("../index.js");
+
+
+fluid.defaults("gpii.tests.userListener.testListener", {
+    gradeNames: ["fluid.component", "fluid.contextAware", "gpii.userListener"],
+    invokers: {
+        startListener: "fluid.identity",
+        stopListener: "fluid.identity"
+    },
+    members: {
+        listenerName: "testListener"
+    }
+});
+
+
+var teardowns = [];
+jqUnit.module("gpii.tests.userListener", {
+    teardown: function () {
+        while (teardowns.length) {
+            teardowns.pop()();
+        }
+    }
+});
+
+gpii.tests.userListener.toggleModeTests = fluid.freezeRecursive({
+    "maintained-short": {
+        momentary: false,
+        detectMode: false,
+        time: 1,
+        expect: ["login", "logout"]
+    },
+    "maintained-long": {
+        momentary: false,
+        detectMode: false,
+        time: 100,
+        expect: ["login", "logout"]
+    },
+    "momentary-short": {
+        momentary: true,
+        detectMode: false,
+        time: 1,
+        expect: ["proximityTriggered", null, "proximityTriggered", null]
+    },
+    "momentary-long": {
+        momentary: true,
+        detectMode: false,
+        time: 100,
+        expect: ["proximityTriggered", null, "proximityTriggered", null]
+    },
+    "hybrid-short": {
+        momentary: false,
+        detectMode: true,
+        time: 1,
+        expect: ["login", null, "proximityTriggered", null]
+    },
+    "hybrid-short-again": {
+        momentary: false,
+        detectMode: true,
+        time: 1,
+        expect: ["proximityTriggered", null, "proximityTriggered", null]
+    },
+    "hybrid-long": {
+        momentary: false,
+        detectMode: true,
+        time: 100,
+        expect: ["proximityTriggered", "logout"]
+    },
+    "hybrid-long-again": {
+        momentary: false,
+        detectMode: true,
+        time: 100,
+        expect: ["login", "logout"]
+    },
+    "hybrid-short-momentary": {
+        momentary: true,
+        detectMode: true,
+        time: 1,
+        expect: ["proximityTriggered", null, "proximityTriggered", null]
+    },
+    "hybrid-long-momentary": {
+        momentary: true,
+        detectMode: true,
+        time: 100,
+        expect: ["proximityTriggered", "logout" ]
+    },
+    "hybrid-long-momentary-again": {
+        momentary: true,
+        detectMode: true,
+        time: 100,
+        expect: ["proximityTriggered", "logout" ]
+    }
+});
+
+
+// Tests USB device removal.
+jqUnit.test("User listener - toggle mode timings", function () {
+
+    var tests = gpii.tests.userListener.toggleModeTests;
+    var currentTest;
+    var currentTestKey;
+    var testEvent;
+    var expectIndex;
+
+    fluid.each(tests, function (test) {
+        jqUnit.expect(test.expect.filter(fluid.identity).length * 2);
+    });
+
+    // Mock hrtime to return the desired time, instead of waiting.
+    var hrtimeOrig = process.hrtime;
+    teardowns.push(function () {
+        process.hrtime = hrtimeOrig;
+    });
+    process.hrtime = function (t) {
+        if (t) {
+            // Return the duration
+            return [currentTest.time, 1];
+        } else {
+            // The current time isn't used.
+            return [1, 1];
+        }
+    };
+
+    // Check the correct calls for flow manager.
+    var callFlowManager = function (token, action) {
+        var expectAction = currentTest.expect[expectIndex];
+        fluid.log(testEvent, ": ", action, "+", token);
+
+        if (expectAction === null || (testEvent !== "arrive") && (testEvent !== "remove")) {
+            jqUnit.fail("Unexpected invocation of callFlowManager - " + currentTestKey);
+        }
+
+        jqUnit.assertEquals(testEvent + " action as expected - " + currentTestKey, expectAction, action);
+        jqUnit.assertEquals(testEvent + " token as expected for " + currentTestKey, "token-" + currentTestKey, token);
+    };
+
+    // Create the test listener component.
+    var listeners = gpii.userListeners({
+        components: {
+            testListener: {
+                type: "gpii.tests.userListener.testListener"
+            }
+        },
+        distributeOptions: {
+            record: {
+                callFlowManager: callFlowManager
+            },
+            target: "{that testListener}.options.invokers"
+        }
+    });
+
+    var listener = listeners.testListener;
+
+
+    fluid.each(tests, function (test, key) {
+        currentTest = test;
+        currentTestKey = key;
+
+        listener.momentary = test.momentary;
+        listener.detectMode = test.detectMode;
+        listener.detectModeTimeout = 5;
+
+        for (expectIndex = 0; expectIndex < currentTest.expect.length; expectIndex++) {
+            testEvent = "arrive";
+            listener.events.onTokenArrive.fire(listener, "token-" + currentTestKey);
+            expectIndex++;
+            testEvent = "remove";
+            listener.events.onTokenRemove.fire(listener, "token-" + currentTestKey);
+        }
+
+        testEvent = null;
+    });
+
+});
+


### PR DESCRIPTION
This provides the ability to auto-detect whether or not the user wants to use a token device in a "tap:on / tap:off" or "present:on / remove:off" manner.

- If the token is removed quickly, then it remain keyed in until a token is presented again.
- If the token is removed after a while, then it will key out.

This works for both the external NFC reader, and USB key. The VAIO's proximity device remains the same as before.
