### PR TITLE
GPII-3120: Improve grade inheritance of the PlatformReporter

### DIFF
--- a/gpii/node_modules/deviceReporter/src/DeviceReporter.js
+++ b/gpii/node_modules/deviceReporter/src/DeviceReporter.js
@@ -179,12 +179,11 @@ fluid.defaults("gpii.platformReporter", {
         }
     },
     invokers: {
-        getBasicOS: "gpii.platformReporter.getBasicOS",
         reportPlatform: {
             funcName: "gpii.platformReporter.reportAll",
-            args: ["{that}", "{that}.getOSspecifics"]
+            args: ["{that}"]
         },
-        getOSspecifics: "fluid.identity"
+        getBasicOS: "gpii.platformReporter.getBasicOS"
     }
 });
 
@@ -207,10 +206,10 @@ gpii.platformReporter.getBasicOS = function () {
  * and so on.
  *
  * @param that (Component)  A platform reporter instance.
- * @param getOSspecifics {Function} The context specific function to call to
- *                                  acquire OS specific platform information.
+ * @return (Object) An object that has properties describing platform
+ *                  features/capabilities; at least basic information such ss
+ *                  the version of the OS.
  */
-gpii.platformReporter.reportAll = function (that, getOSspecifics) {
-    var allInfo = that.getBasicOS();
-    return Object.assign(allInfo, getOSspecifics());
+gpii.platformReporter.reportAll = function (that) {
+    return that.getBasicOS();
 };

--- a/gpii/node_modules/deviceReporter/src/DeviceReporter.js
+++ b/gpii/node_modules/deviceReporter/src/DeviceReporter.js
@@ -190,7 +190,7 @@ fluid.defaults("gpii.platformReporter", {
 /**
  * Returns the OS name and its version.
  *
- * @return (Object) An object consisting of "id" and "version" properties.
+ * @return (Object) - An object consisting of "id" and "version" properties.
  */
 gpii.platformReporter.getBasicOS = function () {
     return {
@@ -205,8 +205,8 @@ gpii.platformReporter.getBasicOS = function () {
  * Returns platform information such as OS, OS version, screen resolution
  * and so on.
  *
- * @param that (Component)  A platform reporter instance.
- * @return (Object) An object that has properties describing platform
+ * @param (Component) that - A platform reporter instance.
+ * @return (Object) - An object that has properties describing platform
  *                  features/capabilities; at least basic information such ss
  *                  the version of the OS.
  */

--- a/gpii/node_modules/deviceReporter/src/DeviceReporter.js
+++ b/gpii/node_modules/deviceReporter/src/DeviceReporter.js
@@ -40,7 +40,7 @@ fluid.defaults("gpii.deviceReporter.base", {
     },
     components: {
         platformReporter: {
-            type: "gpii.platformReporter.native"
+            type: "gpii.platformReporter"
         },
         nameResolver: {
             type: "gpii.deviceReporter.nameResolver"
@@ -162,21 +162,55 @@ gpii.deviceReporter.filterByInstalledSolutions = function (entries, deviceReport
     return installedSolutions;
 };
 
-fluid.defaults("gpii.platformReporter.native", {
-    gradeNames: ["fluid.component"],
-    invokers: {
-        reportPlatform: {
-            funcName: "gpii.platformReporter.native.reportPlatform"
+fluid.defaults("gpii.platformReporter", {
+    gradeNames: ["fluid.component", "fluid.contextAware"],
+    contextAwareness: {
+        platform: {
+            checks: {
+                linux: {
+                    contextValue: "{gpii.contexts.linux}",
+                    gradeNames: "gpii.platformReporter.linux"
+                },
+                windows: {
+                    contextValue: "{gpii.contexts.windows}",
+                    gradeNames: "gpii.platformReporter.windows"
+                }
+            }
         }
+    },
+    invokers: {
+        getBasicOS: "gpii.platformReporter.getBasicOS",
+        reportPlatform: {
+            funcName: "gpii.platformReporter.reportAll",
+            args: ["{that}", "{that}.reportOSinfo"]
+        },
+        reportOSinfo: "fluid.identity"
     }
 });
 
-gpii.platformReporter["native"].reportPlatform = function () { // "native" is a reserved word
+/**
+ * Returns the OS name and its version.
+ *
+ * @return (Object) An object consisting of "id" and "version" properties.
+ */
+gpii.platformReporter.getBasicOS = function () {
     return {
-        // TODO: need to report more details - windowmanager, etc.
         id: os.platform(),
         // TODO: Need a better strategy - Node semver fails horribly
         // in the face of the benign underscore (eg. x86_64).
         version: os.release().replace("_", "-")
     };
+};
+
+/**
+ * Returns platform information such as OS, OS version, screen resolution
+ * and so on.
+ *
+ * @param that (Component)  A platform reporter instance.
+ * @param reportOSinfo {Function} The context specific function to call to
+ *                                cquire OS specific platform information.
+ */
+gpii.platformReporter.reportAll = function (that, reportOSinfo) {
+    var allInfo = that.getBasicOS();
+    return Object.assign(allInfo, reportOSinfo());
 };

--- a/gpii/node_modules/deviceReporter/src/DeviceReporter.js
+++ b/gpii/node_modules/deviceReporter/src/DeviceReporter.js
@@ -182,9 +182,9 @@ fluid.defaults("gpii.platformReporter", {
         getBasicOS: "gpii.platformReporter.getBasicOS",
         reportPlatform: {
             funcName: "gpii.platformReporter.reportAll",
-            args: ["{that}", "{that}.reportOSinfo"]
+            args: ["{that}", "{that}.getOSspecifics"]
         },
-        reportOSinfo: "fluid.identity"
+        getOSspecifics: "fluid.identity"
     }
 });
 
@@ -207,10 +207,10 @@ gpii.platformReporter.getBasicOS = function () {
  * and so on.
  *
  * @param that (Component)  A platform reporter instance.
- * @param reportOSinfo {Function} The context specific function to call to
- *                                cquire OS specific platform information.
+ * @param getOSspecifics {Function} The context specific function to call to
+ *                                  acquire OS specific platform information.
  */
-gpii.platformReporter.reportAll = function (that, reportOSinfo) {
+gpii.platformReporter.reportAll = function (that, getOSspecifics) {
     var allInfo = that.getBasicOS();
-    return Object.assign(allInfo, reportOSinfo());
+    return Object.assign(allInfo, getOSspecifics());
 };

--- a/gpii/node_modules/deviceReporter/test/PlatformReporterTests.js
+++ b/gpii/node_modules/deviceReporter/test/PlatformReporterTests.js
@@ -23,7 +23,7 @@ fluid.registerNamespace("gpii.tests.platformReporter");
 fluid.defaults("gpii.tests.platformReporter", {
     gradeNames: ["gpii.platformReporter", "gpii.contexts.test"],
     invokers: {
-        reportOSinfo: "gpii.tests.platformReporter.reportOSinfo"
+        getOSspecifics: "gpii.tests.platformReporter.getOSspecifics"
     }
 });
 
@@ -42,7 +42,7 @@ gpii.tests.platformReporter.OSinfo = fluid.freezeRecursive({
  *
  * @return {Object} Current and available screen resolutions.
  */
-gpii.tests.platformReporter.reportOSinfo = function () {
+gpii.tests.platformReporter.getOSspecifics = function () {
     return gpii.tests.platformReporter.OSinfo;
 };
 
@@ -61,9 +61,9 @@ jqUnit.test(
     }
 );
 jqUnit.test(
-    "Test reportOSinfo()",
+    "Test getOSspecifics()",
     function () {
-        var OSinfo = platformReporter.reportOSinfo();
+        var OSinfo = platformReporter.getOSspecifics();
         jqUnit.assertDeepEq(
             "Platform OS informaiton",
             gpii.tests.platformReporter.OSinfo,

--- a/gpii/node_modules/deviceReporter/test/PlatformReporterTests.js
+++ b/gpii/node_modules/deviceReporter/test/PlatformReporterTests.js
@@ -43,8 +43,8 @@ gpii.tests.platformReporter.OSinfo = fluid.freezeRecursive({
 /**
  * Return a mock of screen resolutions.
  *
- * @param that (Component)  A platform reporter instance.
- * @return {Object} Basic OS + current and available screen resolutions.
+ * @param (Component) that - A platform reporter instance.
+ * @return {Object} - Basic OS + current and available screen resolutions.
  */
 gpii.tests.platformReporter.reportAll = function (that) {
     var allInfo = that.getBasicOS();

--- a/gpii/node_modules/deviceReporter/test/PlatformReporterTests.js
+++ b/gpii/node_modules/deviceReporter/test/PlatformReporterTests.js
@@ -1,0 +1,99 @@
+/*
+ * GPII Web-based PlatformReporter unit tests/
+ *
+ * Copyright 2017 Inclusive Design Research Centre, OCAD University
+ *
+ * Licensed under the New BSD license. You may not use this file except in
+ * compliance with this License.  You may obtain a copy of the License at
+ * https://github.com/gpii/universal/LICENSE.txt
+ */
+
+/* global require */
+
+"use strict";
+
+var fluid = require("infusion"),
+    jqUnit = fluid.require("node-jqunit");
+
+require("../index.js");
+
+var gpii = fluid.registerNamespace("gpii");
+fluid.registerNamespace("gpii.tests.platformReporter");
+
+fluid.defaults("gpii.tests.platformReporter", {
+    gradeNames: ["gpii.platformReporter", "gpii.contexts.test"],
+    invokers: {
+        reportOSinfo: "gpii.tests.platformReporter.reportOSinfo"
+    }
+});
+
+// Mock OS info, e.g., screen resolutions.
+gpii.tests.platformReporter.OSinfo = fluid.freezeRecursive({
+    "screen-resolution": { width: 640, height: 480 },
+    "available-resolutions": [
+        { width: 640, height: 480 },
+        { width: 1440, height: 900 },
+        { width: 1680, height: 1050 }
+    ]
+});
+
+/**
+ * Return a mock of screen resolutions.
+ *
+ * @return {Object} Current and available screen resolutions.
+ */
+gpii.tests.platformReporter.reportOSinfo = function () {
+    return gpii.tests.platformReporter.OSinfo;
+};
+
+var platformReporter = gpii.tests.platformReporter();
+
+jqUnit.module("Platform Reporter");
+jqUnit.test(
+    "Test getBasicOS()",
+    function () {
+        var basicOS = platformReporter.getBasicOS();
+        jqUnit.assertDeepEq(
+            "Basic OS informaiton", 2, Object.keys(basicOS).length
+        );
+        jqUnit.assertNotNull("ID property", basicOS.id);
+        jqUnit.assertNotNull("Version property", basicOS.version);
+    }
+);
+jqUnit.test(
+    "Test reportOSinfo()",
+    function () {
+        var OSinfo = platformReporter.reportOSinfo();
+        jqUnit.assertDeepEq(
+            "Platform OS informaiton",
+            gpii.tests.platformReporter.OSinfo,
+            OSinfo
+        );
+    }
+);
+jqUnit.test(
+    "Test reportPlatform()",
+    function () {
+        var platform = platformReporter.reportPlatform();
+        jqUnit.assertEquals(
+            "OS ID",
+            platformReporter.getBasicOS().id,
+            platform.id
+        );
+        jqUnit.assertEquals(
+            "OS Version",
+            platformReporter.getBasicOS().version,
+            platform.version
+        );
+        jqUnit.assertDeepEq(
+            "Screen resolution",
+            gpii.tests.platformReporter.OSinfo["screen-resolution"],
+            platform["screen-resolution"]
+        );
+        jqUnit.assertDeepEq(
+            "Available resolutions",
+            gpii.tests.platformReporter.OSinfo["available-resolutions"],
+            platform["available-resolutions"]
+        );
+    }
+);

--- a/gpii/node_modules/deviceReporter/test/PlatformReporterTests.js
+++ b/gpii/node_modules/deviceReporter/test/PlatformReporterTests.js
@@ -23,7 +23,10 @@ fluid.registerNamespace("gpii.tests.platformReporter");
 fluid.defaults("gpii.tests.platformReporter", {
     gradeNames: ["gpii.platformReporter", "gpii.contexts.test"],
     invokers: {
-        getOSspecifics: "gpii.tests.platformReporter.getOSspecifics"
+        reportPlatform: {
+            funcName: "gpii.tests.platformReporter.reportAll",
+            args: ["{that}"]
+        }
     }
 });
 
@@ -40,10 +43,12 @@ gpii.tests.platformReporter.OSinfo = fluid.freezeRecursive({
 /**
  * Return a mock of screen resolutions.
  *
- * @return {Object} Current and available screen resolutions.
+ * @param that (Component)  A platform reporter instance.
+ * @return {Object} Basic OS + current and available screen resolutions.
  */
-gpii.tests.platformReporter.getOSspecifics = function () {
-    return gpii.tests.platformReporter.OSinfo;
+gpii.tests.platformReporter.reportAll = function (that) {
+    var allInfo = that.getBasicOS();
+    return Object.assign(allInfo, gpii.tests.platformReporter.OSinfo);
 };
 
 var platformReporter = gpii.tests.platformReporter();
@@ -58,17 +63,6 @@ jqUnit.test(
         );
         jqUnit.assertNotNull("ID property", basicOS.id);
         jqUnit.assertNotNull("Version property", basicOS.version);
-    }
-);
-jqUnit.test(
-    "Test getOSspecifics()",
-    function () {
-        var OSinfo = platformReporter.getOSspecifics();
-        jqUnit.assertDeepEq(
-            "Platform OS informaiton",
-            gpii.tests.platformReporter.OSinfo,
-            OSinfo
-        );
     }
 );
 jqUnit.test(

--- a/gpii/node_modules/deviceReporter/test/all-tests.js
+++ b/gpii/node_modules/deviceReporter/test/all-tests.js
@@ -1,0 +1,27 @@
+/**
+ * GPII Device Reporter Tests
+ *
+ * Copyright 2017 Inclusive Design Research Centre, OCAD University
+ *
+ * Licensed under the New BSD license. You may not use this file except in
+ * compliance with this License.
+ *
+ * You may obtain a copy of the License at
+ * https://github.com/gpii/universal/LICENSE.txt
+ */
+"use strict";
+
+var fluid = require("infusion"),
+    kettle = fluid.require("kettle");
+
+kettle.loadTestingSupport();
+
+var testIncludes = [
+    "./PlatformReporterTests.js"
+];
+
+var tests = [];
+
+fluid.each(testIncludes, function (path) {
+    tests = tests.concat(fluid.require(path, require));
+});

--- a/tests/all-tests.js
+++ b/tests/all-tests.js
@@ -79,7 +79,8 @@ var testIncludes = [
     "../gpii/node_modules/settingsHandlers/test/WebSocketsSettingsHandlerTests.js",
     "../gpii/node_modules/settingsHandlers/test/settingsHandlerUtilitiesTests.js",
     "../gpii/node_modules/singleInstance/test/SingleInstanceTests.js",
-    "../gpii/node_modules/userListeners/test/all-tests.js"
+    "../gpii/node_modules/userListeners/test/all-tests.js",
+    "../gpii/node_modules/deviceReporter/test/all-tests.js"
 ];
 
 fluid.each(testIncludes, function (path) {


### PR DESCRIPTION
Replace the PlatformReporter's "native" invoker using infusion's context awareness.  That is, implement the OS specific (native) functionality via a grade that capitalizes on a windows context, or linux context, or testing context, etc.

This pull against universal provides the basis for the switch to context awareness:  one of the grade names for the PlatformReporter is "fluid.contextAware".  The actual OS specific implementation is done in, for example, the Windows PlatformReporter that implements the "gpii.platformReporter.windows" context.  Windows and Linux pull requests forthcoming.
