### PR TITLE
GPII-3208: Added ".exe" to the nvda process name to correctly detect if it's running.

### DIFF
--- a/testData/solutions/win32.json5
+++ b/testData/solutions/win32.json5
@@ -1666,7 +1666,7 @@
                     "getState": [
                         {
                             "type": "gpii.processReporter.find",
-                            "command": "nvda"
+                            "command": "nvda.exe"
                         }
                     ],
                     "setTrue": [


### PR DESCRIPTION
Fixes the "nvda doesn't close" bug discovered by Gregg, the actual problem being GPII thought NVDA wasn't running.

https://lists.gpii.net/pipermail/architecture/2018-July/004833.html

