### PR TITLE
NOJIRA - Streamline Vagrantfile and remove dependency on Ansible

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,40 +3,29 @@
 
 require 'yaml'
 
-vars = YAML.load_file("provisioning/vars.yml")
-vagrant_vars = YAML.load_file("provisioning/vagrant-vars.yml")
+# Application definitions
+app_name = "universal"
+app_directory = "/home/vagrant/sync/universal"
 
-app_name = vars["nodejs_app_name"]
+# Port-forwarding definitions
+preferences_server_port = ENV["VM_PREFERENCES_SERVER_PORT"] ||  9081
+flow_manager_port = ENV["VM_FLOW_MANAGER_PORT"] || 9082
+couchdb_port = ENV["VM_COUCHDB_PORT"] || 5984
 
-app_directory = vagrant_vars["nodejs_app_install_dir"]
-
-app_start_script = vars["nodejs_app_start_script"]
-
-# Prepare the port forwarding for the preferences server
-# Check for the existence of the 'VM_PREFERENCES_SERVER_PORT' environment variable. If it
-# doesn't exist but 'nodejs_preferences_server_port' is defined in vars.yml, then use that
-# port. The default port for the preferences server is 9081.
-host_preferences_server_port = ENV["VM_PREFERENCES_SERVER_PORT"] || vars["nodejs_preferences_server_port"] || 9081
-guest_preferences_server_port = vars["nodejs_preferences_server_port"] || 9081
-
-# Prepare the port forwarding for the preferences server
-host_flow_manager_port = ENV["VM_FLOW_MANAGER_PORT"] || vars["nodejs_flow_manager_port"] || 9082
-guest_flow_manager_port = vars["nodejs_flow_manager_port"] || 9082
-
-# Prepare the port forwarding for CouchDB
-host_couchdb_port = ENV["VM_FLOW_MANAGER_PORT"] || vars["nodejs_couchdb_port"] || 9082
-guest_couchdb_port = vars["nodejs_couchdb_port"] || 9082
-
-# By default this VM will use 2 processor cores and 2GB of RAM. The 'VM_CPUS' and
-# "VM_RAM" environment variables can be used to change that behaviour.
+# CPU/memory allocation
 cpus = ENV["VM_CPUS"] || 2
 ram = ENV["VM_RAM"] || 2048
 
+# Node.js
+nodejs_branch = "8"
+nodejs_version = "8.11.3"
+
 Vagrant.configure(2) do |config|
 
-  config.vm.box = "inclusivedesign/fedora27"
+  config.vm.box = "inclusivedesign/fedora28"
+  config.vm.hostname = app_name
 
-  # Your working directory will be synced to /home/vagrant/sync in the VM.
+  # Shared folder
   config.vm.synced_folder ".", "#{app_directory}"
 
   # Mounts node_modules in /var/tmp to work around issues in the VirtualBox shared folders
@@ -46,29 +35,12 @@ Vagrant.configure(2) do |config|
     sudo mount -o bind /var/tmp/#{app_name}/node_modules #{app_directory}/node_modules
   SHELL
 
-  # List additional directories to sync to the VM in your "Vagrantfile.local" file
-  # using the following format:
-  # config.vm.synced_folder "../path/on/your/host/os/your-project", "/home/vagrant/sync/your-project"
+  # Por-forwarding
+  config.vm.network "forwarded_port", guest: preferences_server_port, host: preferences_server_port, protocol: "tcp", auto_correct: true
+  config.vm.network "forwarded_port", guest: flow_manager_port, host: flow_manager_port, protocol: "tcp", auto_correct: true
+  config.vm.network "forwarded_port", guest: couchdb_port, host: couchdb_port, protocol: "tcp", auto_correct: true
 
-  if File.exist? "Vagrantfile.local"
-    instance_eval File.read("Vagrantfile.local"), "Vagrantfile.local"
-  end
-
-  # Port forwarding takes place here. The 'guest' port is used inside the VM
-  # whereas the 'host' port is used by your host operating system.
-  config.vm.network "forwarded_port", guest: guest_preferences_server_port, host: host_preferences_server_port, protocol: "tcp",
-    auto_correct: true
-  config.vm.network "forwarded_port", guest: guest_flow_manager_port, host: host_flow_manager_port, protocol: "tcp",
-    auto_correct: true
-  config.vm.network "forwarded_port", guest: guest_couchdb_port, host: host_couchdb_port, protocol: "tcp",
-    auto_correct: true
-
-  # Port 19531 is needed so logs can be viewed using systemd-journal-gateway
-  #config.vm.network "forwarded_port", guest: 19531, host: 19531, protocol: "tcp",
-  #  auto_correct: true
-
-  config.vm.hostname = app_name
-
+  # VirtualBox customizations
   config.vm.provider :virtualbox do |vm|
     vm.customize ["modifyvm", :id, "--memory", ram]
     vm.customize ["modifyvm", :id, "--cpus", cpus]
@@ -79,16 +51,15 @@ Vagrant.configure(2) do |config|
     vm.customize ["setextradata", "global", "GUI/SuppressMessages", "all"]
   end
 
+  # Install OS-level requirements
   config.vm.provision "shell", inline: <<-SHELL
-    sudo ansible-galaxy install -fr #{app_directory}/provisioning/requirements.yml
-    sudo UNIVERSAL_VARS_FILE=vagrant-vars.yml PYTHONUNBUFFERED=1 ansible-playbook #{app_directory}/provisioning/playbook.yml --tags="install,configure" --inventory="localhost ansible_connection=local,"
+    dnf install -y --disablerepo='*' https://rpm.nodesource.com/pub_#{nodejs_branch}.x/fc/28/x86_64/nodesource-release-fc28-1.noarch.rpm
+    dnf install -y --repo=nodesource nodejs-#{nodejs_version}
   SHELL
 
-  # Using config.vm.hostname to set the hostname on Fedora VMs seems to remove the string
-  # "localhost" from the first line of /etc/hosts. This script reinserts it if it's missing.
-  # https://github.com/mitchellh/vagrant/pull/6203
-  config.vm.provision "shell",
-    inline: "/usr/local/bin/edit-hosts.sh",
-    run: "always"
-
+  # Application-specific commands
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+    cd #{app_directory}
+    npm install
+  SHELL
 end


### PR DESCRIPTION
This PR is just an exercise to verify the overhead of our various customization options.

What it does:
- Updates to Fedora 28
- Removes dependency on Ansible entirely (no customizations enabled by the nodejs role)
- Forces guest/host ports to be the same (less chance for confusion with port-forwarding)
- Deletes the provisioning directory and move bare minimum options at the top of the Vagrantfile  
- Install Node.js and runs `npm install`

As a side-effect, the output of `npm install` is visible and can be inspected.

In my tests this has decreased the setup time to less than half but I would like to test in CI to confirm.

As far as I know, this addresses the needs of CI but it's possible people have more complex environments that would break as a result. Thus, I'm not proposing this be merged as-is, specially since it has not been discussed or had any consensus. 

One alternative would be to have a separate Vagrantfile that is focused on spinning up a full-blown dev environment (or one that is CI-specific).