### PR TITLE
GPII-3283: proximityTrigger / noUser hack

### DIFF
--- a/gpii/node_modules/userListeners/src/listeners.js
+++ b/gpii/node_modules/userListeners/src/listeners.js
@@ -52,7 +52,18 @@ fluid.defaults("gpii.userListeners", {
         "onListenersStop": null
     },
     listeners: {
-        "onCreate.startListeners": "{that}.events.onListenersStart"
+        "onCreate.startListeners": "{that}.events.onListenersStart",
+
+        // Temporary hack for GPII-3283
+        "{lifecycleManager}.events.onSessionStart": {
+            funcName: "gpii.userListeners.sessionChange",
+            args: ["{that}", true, "{arguments}.1"]
+        },
+        "{lifecycleManager}.events.onSessionStop": {
+            funcName: "gpii.userListeners.sessionChange",
+            args: ["{that}", false, null]
+        }
+
     }
 });
 
@@ -121,6 +132,16 @@ fluid.defaults("gpii.userListener", {
     failDelay: 10
 });
 
+// Temporary hack for GPII-3283, to keep an eye on the session state.
+gpii.userListeners.sessionLoggedin = false;
+gpii.userListeners.sessionChange = function (that, sessionStarted, gpiiKey) {
+    if (sessionStarted) {
+        gpii.userListeners.sessionLoggedin = gpiiKey !== "noUser";
+    } else {
+        gpii.userListeners.sessionLoggedin = false;
+    }
+};
+
 /**
  * Handles the onTokenArrive event.
  *
@@ -153,7 +174,11 @@ gpii.userListeners.tokenRemoved = function (that, token) {
     if (!that.proximity) {
         // temporary hack while unable to logout due to "noUser" being logged in, even though a real user is.
         // see GPII-3283
-        request("http://localhost:8081/user/" + token + "/proximityTriggered");
+        if (gpii.userListeners.sessionLoggedin) {
+            request("http://localhost:8081/user/" + token + "/proximityTriggered");
+        } else {
+            fluid.log("Token removed, but there isn't a user keyed in - doing nothing");
+        }
         // request("http://localhost:8081/user/" + token + "/logout");
     }
 };


### PR DESCRIPTION
Don't call proximityTrigger when removing the USB key and if not logged in.