### PR TITLE
GPII-3284: Fixed the config used by QSS/PSP 

### DIFF
--- a/gpii/configs/gpii.config.untrusted.development.dynamicDR.json5
+++ b/gpii/configs/gpii.config.untrusted.development.dynamicDR.json5
@@ -8,6 +8,14 @@
  */
 {
     "type": "gpii.config.untrusted.development.dynamicDR",
+    "options": {
+        "distributeOptions": {
+            "gpii.config.deviceReporter.flowManager": {
+                "record": "{flowManager}.solutionsRegistryDataSource",
+                "target": "{that gpii.deviceReporter.live}.options.components.solutionsRegistryDataSource"
+            }
+        }
+    },
     "mergeConfigs": [
         "../node_modules/deviceReporter/configs/gpii.deviceReporter.config.dynamic.json5",
         "../node_modules/flowManager/configs/gpii.flowManager.config.untrusted.base.json5"


### PR DESCRIPTION
To start untrusted local flow manager with dynamic device reporter.