### PR TITLE
GPII-3378: Fix an issue with sequentially applying a new setting

### DIFF
--- a/gpii/node_modules/lifecycleManager/src/LifecycleManager.js
+++ b/gpii/node_modules/lifecycleManager/src/LifecycleManager.js
@@ -493,24 +493,7 @@ var gpii = fluid.registerNamespace("gpii");
             fluid.set(fullPayload, ["solutionsRegistryEntries"], newPayload.solutionsRegistryEntries);
             that.addLifecycleInstructionsToPayload(fullPayload);
 
-            var transaction = session.applier.initiate("local", "userUpdate");
-            transaction.fireChangeRequest({
-                type: "ADD",
-                segs: ["solutionsRegistryEntries"],
-                value: newPayload.solutionsRegistryEntries
-            });
-            transaction.fireChangeRequest({
-                type: "ADD",
-                segs: ["activeConfiguration"],
-                value: fullPayload.activeConfiguration
-            });
-            transaction.fireChangeRequest({
-                type: "ADD",
-                segs: ["preferences"],
-                value: newPrefsSet
-            });
-            transaction.commit();
-
+            session.applier.change("", fullPayload, "ADD", "userUpdate");
             that.update(fullPayload).then(prefsAppliedLocalEvent.fire);
         });
     };

--- a/tests/shared/PSPIntegrationTestDefs.js
+++ b/tests/shared/PSPIntegrationTestDefs.js
@@ -118,6 +118,27 @@ gpii.tests.pspIntegration.data = {
             }
         }
     },
+    afterDecreaseCursorSize: {
+        "settingsHandlers": {
+            "gpii.gsettings": {
+                "data": [{
+                    "settings": {
+                        "cursor-size": 29
+                    },
+                    "options": {
+                        "schema": "org.gnome.desktop.interface"
+                    }
+                }]
+            },
+            "gpii.alsa": {
+                "data": [{
+                    "settings": {
+                        "masterVolume": 50
+                    }
+                }]
+            }
+        }
+    },
     afterChangeVolume: {
         "settingsHandlers": {
             "gpii.gsettings": {
@@ -218,8 +239,8 @@ gpii.tests.pspIntegration.testDefs = [
             ]
         ]
     }, {
-        name: "Simple settings change by PSP - change a new setting",
-        expect: 9,
+        name: "Simple settings change by PSP - sequentially change a new setting",
+        expect: 11,
         sequence: [
             [
                 {
@@ -265,6 +286,19 @@ gpii.tests.pspIntegration.testDefs = [
                 }, {
                     func: "gpii.test.checkConfiguration",
                     args: ["{tests}.options.data.afterChangeCursorSize.settingsHandlers", "{nameResolver}", "{testCaseHolder}.events.onCheckConfigurationComplete.fire"]
+                }, {
+                    event: "{testCaseHolder}.events.onCheckConfigurationComplete",
+                    listener: "fluid.identity"
+                }, {
+                    funcName: "gpii.tests.pspIntegration.sendMsg",
+                    args: [ "{pspClient}", [ "preferences","http://registry\\.gpii\\.net/common/cursorSize"], 0.5]
+                }, {
+                    event: "{pspClient}.events.onReceiveMessage",
+                    listener: "gpii.tests.pspIntegration.checkPayload",
+                    args: ["{arguments}.0", "preferencesApplied"]
+                }, {
+                    func: "gpii.test.checkConfiguration",
+                    args: ["{tests}.options.data.afterDecreaseCursorSize.settingsHandlers", "{nameResolver}", "{testCaseHolder}.events.onCheckConfigurationComplete.fire"]
                 }, {
                     event: "{testCaseHolder}.events.onCheckConfigurationComplete",
                     listener: "fluid.identity"


### PR DESCRIPTION
@amb26, in [my previous pull request for GPII-3378](https://github.com/GPII/universal/pull/661), there was a bug that when sequentially applying changes for a new preference, only the first change would be successfully applied and the following would fail. 

This pull request contains a test to demonstrate the problem as well as a fix for it.

Please have a look. Thanks.