### PR TITLE
GPII-3389: Updated test data to use JAWS 2018.

### DIFF
--- a/gpii/node_modules/contextManager/test/data/standardMMInput.json
+++ b/gpii/node_modules/contextManager/test/data/standardMMInput.json
@@ -80,7 +80,7 @@
                 "configuration1": {
                     "type": "gpii.settingsHandlers.INISettingsHandler",
                     "options": {
-                        "filename": "${{environment}.APPDATA}\\Freedom Scientific\\JAWS\\17.0\\Settings\\enu\\DEFAULT.JCF"
+                        "filename": "${{environment}.APPDATA}\\Freedom Scientific\\JAWS\\2018\\Settings\\enu\\DEFAULT.JCF"
                     },
                     "supportedSettings": {},
                     "capabilitiesTransformations": {},
@@ -89,7 +89,7 @@
                 "configuration2": {
                     "type": "gpii.settingsHandlers.INISettingsHandler",
                     "options": {
-                        "filename": "${{environment}.APPDATA}\\Freedom Scientific\\JAWS\\17.0\\Settings\\VoiceProfiles\\GPII.VPF"
+                        "filename": "${{environment}.APPDATA}\\Freedom Scientific\\JAWS\\2018\\Settings\\VoiceProfiles\\GPII.VPF"
                     },
                     "supportedSettings": {
                         "Options.PrimarySynthesizer": {},


### PR DESCRIPTION
See [GPII-3389](https://issues.gpii.net/browse/GPII-3389) for details.