### PR TITLE
GPII-3402: "Contact Technical Support" link to User Errors

### DIFF
--- a/gpii/node_modules/gpii-user-errors/bundles/gpii-userErrors-messageBundle_en.json5
+++ b/gpii/node_modules/gpii-user-errors/bundles/gpii-userErrors-messageBundle_en.json5
@@ -1,10 +1,10 @@
 {
     "gpii_userErrors_EADDRINUSE-title": "Morphic can't start",
     "gpii_userErrors_EADDRINUSE-subhead": "There is another application listening on the same port",
-    "gpii_userErrors_EADDRINUSE-details": "Stop the other running application and try again. If the problem is still present, contact Morphic Technical Support.",
+    "gpii_userErrors_EADDRINUSE-details": "Stop the other running application and try again. If the problem is still present, <a href='https://morphic.world/contact/'>contact Morphic Technical Support</a>.",
     "gpii_userErrors_KeyInFail-title":   "Oops.",
     "gpii_userErrors_KeyInFail-subhead": "Something went wrong.",
-    "gpii_userErrors_KeyInFail-details": "Try restarting your computer. If this problem continues, contact Morphic Technical Support.",
+    "gpii_userErrors_KeyInFail-details": "Try restarting your computer. If this problem continues, <a href='https://morphic.world/contact/'>contact Morphic Technical Support</a>.",
     // Note that the "NoConnection" error is currently not fired
     "gpii_userErrors_NoConnection-title":   "No Internet connection",
     "gpii_userErrors_NoConnection-subhead": "Morphic cannot see the cloud to get your settings.",


### PR DESCRIPTION
Adds a simple html `anchor` tags to User Error messages. These are handled properly in the `gpii.app` by the `gpii.app.errorDialog`.