### PR TITLE
GPII-3414: Added liveness directive to com.microsoft.windows.language

### DIFF
--- a/testData/solutions/win32.json5
+++ b/testData/solutions/win32.json5
@@ -3996,6 +3996,7 @@
         "settingsHandlers": {
             "configure1": {
                 "type": "gpii.windows.registrySettingsHandler",
+                "liveness": "liveRestart",
                 "options": {
                     "hKey": "HKEY_CURRENT_USER",
                     "path": "Control Panel\\Desktop\\MuiCached",
@@ -4020,6 +4021,7 @@
             },
             "configure2": {
                 "type": "gpii.windows.registrySettingsHandler",
+                "liveness": "liveRestart",
                 "options": {
                     "hKey": "HKEY_CURRENT_USER",
                     "path": "Control Panel\\Desktop",


### PR DESCRIPTION
We need this to allow the QSS to effectively switch the OS language.