### PR TITLE
GPII-3396: Fix the journal integration test failure on Windows

### DIFF
--- a/tests/JournalIntegrationTests.js
+++ b/tests/JournalIntegrationTests.js
@@ -467,6 +467,10 @@ gpii.tests.journal.fixtures = [
                     }
                 }
             }, gpii.test.checkSequence,
+            {
+                event: "{configuration}.server.flowManager.events.noUserLoggedIn",
+                listener: "fluid.identity",    
+            },
             // Now verify that we can log on normally after a restore, and generate a non-crashed session after logging off
             gpii.tests.journal.normalLoginFixtures
         ]

--- a/tests/JournalIntegrationTests.js
+++ b/tests/JournalIntegrationTests.js
@@ -469,7 +469,7 @@ gpii.tests.journal.fixtures = [
             }, gpii.test.checkSequence,
             {
                 event: "{configuration}.server.flowManager.events.noUserLoggedIn",
-                listener: "fluid.identity",    
+                listener: "fluid.identity"
             },
             // Now verify that we can log on normally after a restore, and generate a non-crashed session after logging off
             gpii.tests.journal.normalLoginFixtures


### PR DESCRIPTION
By starting the normal login process after the restoration when "noUser" login completes.