### PR TITLE
GPII-3422: Fixed the metrics "solution-failed" error for "com.microsoft.windows.volumeControl" solution

### DIFF
--- a/gpii/node_modules/settingsHandlers/src/NoSettingsHandler.js
+++ b/gpii/node_modules/settingsHandlers/src/NoSettingsHandler.js
@@ -19,5 +19,7 @@
 var fluid = require("infusion"),
     settingsHandlers = fluid.registerNamespace("gpii.settingsHandlers");
 
-settingsHandlers.noSettings = fluid.identity;
-settingsHandlers.noSettings.set = fluid.identity;
+fluid.registerNamespace("gpii.settingsHandlers.noSettings");
+
+settingsHandlers.noSettings.get = settingsHandlers.noSettingsGet();
+settingsHandlers.noSettings.set = settingsHandlers.noSettingsSet();

--- a/gpii/node_modules/settingsHandlers/src/NoSettingsHandler.js
+++ b/gpii/node_modules/settingsHandlers/src/NoSettingsHandler.js
@@ -17,9 +17,22 @@
 "use strict";
 
 var fluid = require("infusion"),
-    settingsHandlers = fluid.registerNamespace("gpii.settingsHandlers");
+    gpii = fluid.registerNamespace("gpii");
 
 fluid.registerNamespace("gpii.settingsHandlers.noSettings");
 
-settingsHandlers.noSettings.get = settingsHandlers.noSettingsGet();
-settingsHandlers.noSettings.set = settingsHandlers.noSettingsSet();
+// Get/Set settings handlers for "gpii.settingsHandlers.noSettings"
+gpii.settingsHandlers.noSettingsGet = function () {
+    return function (payload) {
+        return gpii.settingsHandlers.transformPayload(payload, gpii.settingsHandlers.getSettings);
+    };
+};
+
+gpii.settingsHandlers.noSettingsSet = function () {
+    return function (payload) {
+        return gpii.settingsHandlers.transformPayload(payload, gpii.settingsHandlers.setSettings);
+    };
+};
+
+gpii.settingsHandlers.noSettings.get = gpii.settingsHandlers.noSettingsGet();
+gpii.settingsHandlers.noSettings.set = gpii.settingsHandlers.noSettingsSet();

--- a/gpii/node_modules/settingsHandlers/src/settingsHandlerUtilities.js
+++ b/gpii/node_modules/settingsHandlers/src/settingsHandlerUtilities.js
@@ -552,16 +552,3 @@ gpii.settingsHandlers.copySettings = function (target, source) {
         }
     }
 };
-
-// Get/Set settings handlers for "gpii.settingsHandlers.noSettings"
-gpii.settingsHandlers.noSettingsGet = function () {
-    return function (payload) {
-        return gpii.settingsHandlers.transformPayload(payload, gpii.settingsHandlers.getSettings);
-    };
-};
-
-gpii.settingsHandlers.noSettingsSet = function () {
-    return function (payload) {
-        return gpii.settingsHandlers.transformPayload(payload, gpii.settingsHandlers.setSettings);
-    };
-};

--- a/gpii/node_modules/settingsHandlers/src/settingsHandlerUtilities.js
+++ b/gpii/node_modules/settingsHandlers/src/settingsHandlerUtilities.js
@@ -460,8 +460,6 @@ gpii.settingsHandlers.setSettings = function (solutionEntry, currentSettings) {
     return { options: options, settings: newSettingsResponse };
 };
 
-
-
 /**************** FILE DEPENDENCE BELOW THIS POINT *********************/
 
 gpii.settingsHandlers.readFile = function (options) {
@@ -537,6 +535,8 @@ gpii.settingsHandlers.makeFileSet = function (parser) {
     };
 };
 
+/**************** END OF FILE DEPENDENCE *********************/
+
 /*
  * Given two settingsHandler blocks, copy the settings (even those with a value of undefined) from
  * the source to the target - overwriting the target settings. Note that the keys/values immediately
@@ -551,4 +551,17 @@ gpii.settingsHandlers.copySettings = function (target, source) {
             target[shName].settings[setting] = shBlock.settings[setting];
         }
     }
+};
+
+// Get/Set settings handlers for "gpii.settingsHandlers.noSettings"
+gpii.settingsHandlers.noSettingsGet = function () {
+    return function (payload) {
+        return gpii.settingsHandlers.transformPayload(payload, gpii.settingsHandlers.getSettings);
+    };
+};
+
+gpii.settingsHandlers.noSettingsSet = function () {
+    return function (payload) {
+        return gpii.settingsHandlers.transformPayload(payload, gpii.settingsHandlers.setSettings);
+    };
 };

--- a/gpii/node_modules/settingsHandlers/test/NoSettingsHandlerTests.js
+++ b/gpii/node_modules/settingsHandlers/test/NoSettingsHandlerTests.js
@@ -1,0 +1,98 @@
+/*
+ * INI Settings Handler Tests
+ *
+ * Copyright 2018 OCAD University
+ *
+ * Licensed under the New BSD license. You may not use this file except in
+ * compliance with this License.
+ *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/universal/blob/master/LICENSE.txt
+ */
+
+"use strict";
+
+var fluid = require("infusion"),
+    gpii = fluid.registerNamespace("gpii"),
+    jqUnit = fluid.registerNamespace("jqUnit"),
+    kettle = require("kettle");
+
+fluid.registerNamespace("gpii.tests.noSettingsHandler");
+
+kettle.loadTestingSupport();
+
+require("settingsHandlers");
+
+gpii.tests.noSettingsHandler.tests = {
+    basicTest: {
+        set: {
+            payload: {
+                "com.microsoft.windows.volumeControl": [{
+                    settings: {
+                        "volume": 3
+                    }
+                }]
+            },
+            expected: {
+                "com.microsoft.windows.volumeControl": [{
+                    options: undefined,
+                    settings: {
+                        "volume": {
+                            newValue: 3,
+                            oldValue: undefined
+                        }
+                    }
+                }]
+            }
+        },
+        get: {
+            payload: {
+                "com.microsoft.windows.volumeControl": [{
+                    settings: {
+                        "volume": {}
+                    }
+                }]
+            },
+            expected: {
+                "com.microsoft.windows.volumeControl": [{
+                    settings: {
+                        "volume": undefined
+                    }
+                }]
+            }
+        }
+    }
+};
+
+gpii.tests.noSettingsHandler.doTest = function () {
+    fluid.each(gpii.tests.noSettingsHandler.tests, function (oneTest) {
+        var getResult = gpii.settingsHandlers.noSettings.get(oneTest.get.payload);
+        jqUnit.assertDeepEq("The get result is expected", oneTest.get.expected, getResult);
+
+        var setResult = gpii.settingsHandlers.noSettings.set(oneTest.set.payload);
+        jqUnit.assertDeepEq("The set result is expected", oneTest.set.expected, setResult);
+    });
+};
+
+fluid.defaults("gpii.tests.noSettingsHandler", {
+    gradeNames: ["fluid.test.testEnvironment"],
+    components: {
+        tester: {
+            type: "gpii.tests.noSettingsHandler.testCaseHolder"
+        }
+    }
+});
+
+fluid.defaults("gpii.tests.noSettingsHandler.testCaseHolder", {
+    gradeNames: ["fluid.test.testCaseHolder"],
+    modules: [{
+        name: "NoSettingsHandler",
+        tests: [{
+            // expect: 2,
+            name: "Tests for gpii.settingsHandler.noSettingsHandler",
+            func: "gpii.tests.noSettingsHandler.doTest"
+        }]
+    }]
+});
+
+module.exports = kettle.test.bootstrap("gpii.tests.noSettingsHandler");

--- a/gpii/node_modules/settingsHandlers/test/SettingsHandlerUtilitiesTests.js
+++ b/gpii/node_modules/settingsHandlers/test/SettingsHandlerUtilitiesTests.js
@@ -1,0 +1,108 @@
+/*
+ * Settings Handler Utilities Tests
+ *
+ * Copyright 2016 Raising the Floor - International
+ *
+ * Licensed under the New BSD license. You may not use this file except in
+ * compliance with this License.
+ *
+ * The research leading to these results has received funding from the European Union's
+ * Seventh Framework Programme (FP7/2007-2013)
+ * under grant agreement no. 289016.
+ *
+ * You may obtain a copy of the License at
+ * https://github.com/GPII/universal/blob/master/LICENSE.txt
+ */
+
+"use strict";
+
+var fluid = require("infusion"),
+    gpii = fluid.registerNamespace("gpii"),
+    jqUnit = fluid.registerNamespace("jqUnit"),
+    kettle = require("kettle");
+
+fluid.registerNamespace("gpii.tests.settingsHandlers");
+
+kettle.loadTestingSupport();
+
+require("settingsHandlers");
+
+gpii.tests.settingsHandlers.readFile = function () {
+    // check that we're able to read existing file:
+    var result = gpii.settingsHandlers.readFile({
+        filename: __dirname + "/data/basic.json"
+    });
+    jqUnit.assertDeepEq("Expecting to have read the file properly", { Hello: "World" }, JSON.parse(result));
+
+    // check reading non-existing file
+    var result2 = gpii.settingsHandlers.readFile({
+        filename: __dirname + "/data/bogus.json"
+    });
+    jqUnit.assertEquals("Expecting undefined on reading non-existing file", undefined, result2);
+};
+
+var handleFileSolutionEntryData = {
+    existingFileSolutionEntry: {
+        options: {
+            "filename": __dirname + "/data/basic.json"
+        },
+        settings: {
+            "Hello": "Mars"
+        }
+    },
+    missingFileSolutionEntry: {
+        options: {
+            "filename": __dirname + "/data/bogus.json"
+        },
+        settings: {
+            "Hello": "Mars"
+        }
+    }
+};
+
+gpii.tests.settingsHandlers.handleFileSolutionEntry = function () {
+    // an existing file should be parsed and the current value returned:
+    var result = gpii.settingsHandlers.handleFileSolutionEntry(handleFileSolutionEntryData.existingFileSolutionEntry,
+        gpii.settingsHandlers.getSettings, gpii.settingsHandlers.JSONSettingsHandler.parser, false);
+    jqUnit.assertDeepEq("Expecting to have read the file properly", {
+        "settings": {
+            "Hello": "World"
+        }
+    }, result);
+
+    // a non-existing file should return undefined for the requested settings:
+    result = gpii.settingsHandlers.handleFileSolutionEntry(handleFileSolutionEntryData.missingFileSolutionEntry,
+        gpii.settingsHandlers.getSettings, gpii.settingsHandlers.JSONSettingsHandler.parser, false);
+    jqUnit.assertDeepEq("Expecting to get 'undefined' values for settings requested", {
+        "settings": {
+            "Hello": undefined
+        }
+    }, result);
+};
+
+fluid.defaults("gpii.tests.settingsHandlers.env", {
+    gradeNames: ["fluid.test.testEnvironment"],
+    components: {
+        tester: {
+            type: "gpii.tests.settingsHandlers.caseHolder"
+        }
+    }
+});
+
+fluid.defaults("gpii.tests.settingsHandlers.caseHolder", {
+    gradeNames: ["fluid.test.testCaseHolder"],
+    modules: [{
+        name: "File Dependency Methods tests",
+        tests: [{
+            expect: 2,
+            name: "gpii.settingsHandlers.readFile tests",
+            func: "gpii.tests.settingsHandlers.readFile"
+        }, {
+            expect: 2,
+            name: "gpii.settingsHandlers.handleFileSolutionEntry tests",
+            func: "gpii.tests.settingsHandlers.handleFileSolutionEntry"
+        }]
+    }]
+});
+
+module.exports = kettle.test.bootstrap("gpii.tests.settingsHandlers.env");

--- a/testData/solutions/win32.json5
+++ b/testData/solutions/win32.json5
@@ -6421,7 +6421,7 @@
                 }
             }
         },
-        "configure": [],
+        "configure": ["settings.configure"],
         "restore": [],
         "start": [],
         "stop": [],

--- a/testData/solutions/win32.json5
+++ b/testData/solutions/win32.json5
@@ -6414,10 +6414,10 @@
                 "type": "gpii.settingsHandlers.noSettings",
                 "liveness": "live",
                 "capabilitiesTransformations": {
-                    "sc": "http://registry\\.gpii\\.net/common/volume"
+                    "volume": "http://registry\\.gpii\\.net/common/volume"
                 },
                 "supportedSettings": {
-                    "sc": {}
+                    "volume": {}
                 }
             }
         },

--- a/tests/all-tests.js
+++ b/tests/all-tests.js
@@ -69,7 +69,8 @@ var testIncludes = [
     "../gpii/node_modules/settingsHandlers/test/XMLSettingsHandlerTests.js",
     "../gpii/node_modules/settingsHandlers/test/INISettingsHandlerTests.js",
     "../gpii/node_modules/settingsHandlers/test/WebSocketsSettingsHandlerTests.js",
-    "../gpii/node_modules/settingsHandlers/test/settingsHandlerUtilitiesTests.js",
+    "../gpii/node_modules/settingsHandlers/test/NoSettingsHandlerTests.js",
+    "../gpii/node_modules/settingsHandlers/test/SettingsHandlerUtilitiesTests.js",
     "../gpii/node_modules/singleInstance/test/SingleInstanceTests.js",
     "../gpii/node_modules/userListeners/test/all-tests.js",
     "../gpii/node_modules/gpii-ini-file/test/iniFileTests.js"


### PR DESCRIPTION
After some investigation, I found we only need to fix [this line](https://github.com/GPII/universal/compare/master...cindyli:GPII-3422?expand=1#diff-cb7e20a6c5ff97630ea4518024a845b2R6424) for the "com.microsoft.windows.volumeControl" solution in the windows solution registry to get rid of the metrics "solution-failed" error.

However, since I've already improved "gpii.settingsHandler.noSettings" to return payloads, I also include it in this pull request. The benefit of this change is, a clearer logging message of the new volume value will be recorded in the flow manager log file when the new volume is applied.

@amb26, let me know if you think it's better NOT to merge the change for "gpii.settingsHandler.noSettings". Thanks.