### PR TITLE
NOJIRA: Adding an empty preference set for testing purposes

### DIFF
--- a/testData/preferences/empty.json5
+++ b/testData/preferences/empty.json5
@@ -1,0 +1,12 @@
+// An empty snapset for testing purposes
+{
+    "flat": {
+        "name": "Empty",
+        "contexts": {
+            "gpii-default": {
+                "name": "Default preferences",
+                "preferences": {}
+            }
+        }
+    }
+}


### PR DESCRIPTION
Suitable for testing functionalities such as:

- If the PSP is open and a user with no settings keys in, the PSP should be closed
- If a user with no settings has keyed in and the PSP is opened, a dedicated message about the missing settings will be shown.