### PR TITLE
GPII-3449: Logging metrics via TCP

### DIFF
--- a/gpii/node_modules/eventLog/src/eventLog.js
+++ b/gpii/node_modules/eventLog/src/eventLog.js
@@ -57,7 +57,11 @@ fluid.defaults("gpii.eventLog", {
     members: {
         // The installation ID
         installationID: "@expand:{that}.installID.getInstallID()",
-        version: "@expand:{that}.getVersion()"
+        version: "@expand:{that}.getVersion()",
+        // Buffered log lines while there's not log server connection
+        logBuffer: [],
+        // Maximum number of lines to buffer.
+        maxBufferlength: 0xfff
     },
     listeners: {
         "onCreate.logFile": {
@@ -328,12 +332,8 @@ gpii.eventLog.writeLogTcp = function (that, logLine) {
     if (that.logSocket.connecting) {
         // Buffer the output until the connection is made. Socket.write already buffers, however if the connection
         // fails the data will be lost.
-        if (!that.logBuffer) {
-            that.logBuffer = [];
-        }
-        var maxSize = 0xfff;
-        if (that.logBuffer.length > maxSize) {
-            fluid.log("Dropping metrics data - exceeded initial buffer size of " + maxSize);
+        if (that.logBuffer.length > that.maxBufferlength) {
+            fluid.log("Dropping metrics data - exceeded initial buffer size of " + that.maxBufferlength);
         } else {
             that.logBuffer.push(logLine);
         }
@@ -358,9 +358,9 @@ gpii.eventLog.connectLog = function (that) {
         gpii.eventLog.connectLog.lastError = null;
         fluid.log("Connected to log server");
         // Send the initial data.
-        if (that.logBuffer) {
+        if (that.logBuffer.length > 0) {
             that.logSocket.write(that.logBuffer.join(""));
-            that.logBuffer = null;
+            that.logBuffer = [];
         }
     });
 

--- a/gpii/node_modules/eventLog/src/eventLog.js
+++ b/gpii/node_modules/eventLog/src/eventLog.js
@@ -297,7 +297,7 @@ gpii.eventLog.writeLog = function (that, level, event) {
     event.level = intLevel.value;
 
     // Log to console before the installation ID and timestamp are added (no one wants to see it).
-    fluid.log(fluid.logLevel.IMPORTANT, event);
+    fluid.log(fluid.logLevel.TRACE, event);
 
     event.installID = that.installationID;
     event.timestamp = gpii.eventLog.getTimestamp();
@@ -365,7 +365,6 @@ gpii.eventLog.connectLog = function (that) {
     });
 
     that.logSocket.on("close", function () {
-        fluid.log("Log server connection closed");
         if (that.logSocket) {
             that.logSocket.destroy();
             that.logSocket = null;

--- a/gpii/node_modules/eventLog/src/eventLog.js
+++ b/gpii/node_modules/eventLog/src/eventLog.js
@@ -51,11 +51,13 @@ fluid.defaults("gpii.eventLog", {
         },
         logError: "gpii.eventLog.logError",
         getGpiiSettingsDir: "{settingsDir}.getGpiiSettingsDir",
-        getLogFile: "gpii.eventLog.getLogFile"
+        getLogFile: "gpii.eventLog.getLogFile",
+        getVersion: "gpii.eventLog.getVersion"
     },
     members: {
         // The installation ID
-        installationID: "@expand:{that}.installID.getInstallID()"
+        installationID: "@expand:{that}.installID.getInstallID()",
+        version: "@expand:{that}.getVersion()"
     },
     listeners: {
         "onCreate.logFile": {
@@ -108,6 +110,16 @@ fluid.defaults("gpii.eventLog", {
  */
 gpii.eventLog.getTimestamp = function () {
     return moment().toISOString(true);
+};
+
+/**
+ * Gets the version of the logger. This is logged so the log processing can adjust for any updates to this module.
+ *
+ * @return {String} The version of this module, from package.json.
+ */
+gpii.eventLog.getVersion = function () {
+    var packageJson = fluid.require("%eventLog/package.json");
+    return packageJson.version;
 };
 
 /**
@@ -289,6 +301,7 @@ gpii.eventLog.writeLog = function (that, level, event) {
 
     event.installID = that.installationID;
     event.timestamp = gpii.eventLog.getTimestamp();
+    event.version = that.version;
 
     var logLine = JSON.stringify(event) + "\n";
 

--- a/gpii/node_modules/eventLog/src/eventLog.js
+++ b/gpii/node_modules/eventLog/src/eventLog.js
@@ -23,7 +23,8 @@
 var fluid = require("infusion");
 var fs = require("fs"),
     path = require("path"),
-    moment = require("moment");
+    moment = require("moment"),
+    net = require("net");
 
 var gpii = fluid.registerNamespace("gpii"),
     $ = fluid.registerNamespace("jQuery");
@@ -53,8 +54,6 @@ fluid.defaults("gpii.eventLog", {
         getLogFile: "gpii.eventLog.getLogFile"
     },
     members: {
-        // The log file.
-        logFilePath: null,
         // The installation ID
         installationID: "@expand:{that}.installID.getInstallID()"
     },
@@ -97,7 +96,9 @@ fluid.defaults("gpii.eventLog", {
                 }
             ]
         }
-    }
+    },
+
+    logDestination: "tcp://127.0.0.1:51481"
 });
 
 /**
@@ -209,7 +210,7 @@ gpii.eventLog.logError = function (that, moduleName, errType, err, level) {
 
 // Log fluid.fail.
 fluid.failureEvent.addListener(function (args) {
-    var err = Array.isArray(args) ? args.join(" ") : err;
+    var err = Array.isArray(args) ? args.join(" ") : args;
     gpii.eventLog.gotError(err, "Fail");
 }, "gpii-eventLog", "before:fail");
 
@@ -222,7 +223,9 @@ fluid.failureEvent.addListener(function (args) {
 gpii.eventLog.gotError = function (err, errType) {
     var eventLog = fluid.queryIoCSelector(fluid.rootComponent, "gpii.eventLog");
     if (eventLog.length > 0) {
-        eventLog[0].logError(eventLog[0], null, errType || "Exception", err);
+        fluid.each(eventLog, function (inst) {
+            inst.logError(inst, null, errType || "Exception", err);
+        });
     }
 };
 
@@ -231,21 +234,40 @@ fluid.onUncaughtException.addListener(gpii.eventLog.gotError, "gpii-eventLog");
 
 /**
  * Gets the path of the new log file for this instance of gpii.
+ * It can use one of the following environment variables to override the configured:
+ *  GPII_EVENT_LOG: The path to the log file (a file, or tcp://<host>:<port>).
+ *  GPII_EVENT_LOG_DIRECTORY: A directory where per-instance logs are kept
  *
  * @param {Component} that - The gpii.eventLog instance.
  * @return {String} The path to the new log file.
  */
 gpii.eventLog.getLogFile = function (that) {
-    var logFile = that.logFilePath || process.env.GPII_EVENT_LOG;
-
-    if (!logFile) {
-        var startupTime = Date.now();
-        var gpiiSettingsDir = that.getGpiiSettingsDir();
-        logFile = path.join(gpiiSettingsDir, "gpii-" + gpii.journal.formatTimestamp(startupTime) + ".log");
-        fluid.log(fluid.logLevel.IMPORTANT, "Writing event log to " + that.logFilePath);
+    var logPath;
+    if (!process.env.GPII_EVENT_LOG_DIRECTORY) {
+        logPath = process.env.GPII_EVENT_LOG || that.logFilePath || that.options.logDestination;
     }
 
-    that.logFilePath = logFile;
+    if (logPath) {
+        if (logPath.startsWith("tcp:")) {
+            var m = /tcp:\/*([^:]+):([0-9]+)/.exec(logPath);
+            if (m) {
+                that.logHost = m[1];
+                that.logPort = m[2];
+                that.logFilePath = null;
+            }
+        } else {
+            that.logHost = null;
+            that.logFilePath = logPath;
+        }
+    } else {
+        that.logHost = null;
+        var startupTime = Date.now();
+        var gpiiSettingsDir = process.env.GPII_EVENT_LOG_DIRECTORY || that.getGpiiSettingsDir();
+        that.logFilePath = path.join(gpiiSettingsDir, "gpii-" + gpii.journal.formatTimestamp(startupTime) + ".log");
+    }
+
+    var dest = that.logHost ? ("tcp://" + that.logHost + ":" + that.logPort) : that.logFilePath;
+    fluid.log(fluid.logLevel.IMPORTANT, "Writing event log to " + dest);
 
     return that.logFilePath;
 };
@@ -267,7 +289,86 @@ gpii.eventLog.writeLog = function (that, level, event) {
 
     event.installID = that.installationID;
     event.timestamp = gpii.eventLog.getTimestamp();
-    fs.appendFileSync(that.logFilePath, JSON.stringify(event) + "\n");
+
+    var logLine = JSON.stringify(event) + "\n";
+
+    if (that.logHost && that.logPort) {
+        gpii.eventLog.writeLogTcp(that, logLine);
+    }
+
+    if (that.logFilePath) {
+        fs.appendFileSync(that.logFilePath, logLine);
+    }
+};
+
+/**
+ * Sends a log line to the configured log server.
+ *
+ * @param {Component} that - The gpii.eventLog instance.
+ * @param {String} logLine - The log line, including the newline.
+ */
+gpii.eventLog.writeLogTcp = function (that, logLine) {
+    if (!that.logSocket) {
+        gpii.eventLog.connectLog(that);
+    }
+
+    if (that.logSocket.connecting) {
+        // Buffer the output until the connection is made. Socket.write already buffers, however if the connection
+        // fails the data will be lost.
+        if (!that.logBuffer) {
+            that.logBuffer = [];
+        }
+        var maxSize = 0xfff;
+        if (that.logBuffer.length > maxSize) {
+            fluid.log("Dropping metrics data - exceeded initial buffer size of " + maxSize);
+        } else {
+            that.logBuffer.push(logLine);
+        }
+    } else {
+        that.logSocket.write(logLine);
+    }
+
+};
+
+/**
+ * Connect to a TCP port which receives the log data.
+ * @param {Component} that - The gpii.eventLog instance.
+ */
+gpii.eventLog.connectLog = function (that) {
+    if (that.logSocket) {
+        fluid.fail("Already connecting to log server");
+    }
+
+    // Connect to the server.
+    that.logSocket = new net.Socket();
+    that.logSocket.connect(that.logPort, that.logHost, function () {
+        gpii.eventLog.connectLog.lastError = null;
+        fluid.log("Connected to log server");
+        // Send the initial data.
+        if (that.logBuffer) {
+            that.logSocket.write(that.logBuffer.join(""));
+            that.logBuffer = null;
+        }
+    });
+
+    that.logSocket.on("close", function () {
+        fluid.log("Log server connection closed");
+        if (that.logSocket) {
+            that.logSocket.destroy();
+            that.logSocket = null;
+        }
+    });
+
+    that.logSocket.on("error", function (err) {
+        if (gpii.eventLog.connectLog.lastError !== err.code) {
+            fluid.log("Log server socket error:", err);
+            if (that.logSocket) {
+                that.logSocket.destroy();
+            }
+            // Don't repeat the same error again.
+            gpii.eventLog.connectLog.lastError = err.code;
+        }
+    });
 };
 
 /**

--- a/gpii/node_modules/eventLog/src/metrics.js
+++ b/gpii/node_modules/eventLog/src/metrics.js
@@ -28,6 +28,10 @@ fluid.defaults("gpii.metrics", {
     contextAwareness: {
         platform: {
             checks: {
+                test: {
+                    contextValue: "{gpii.contexts.test}",
+                    gradeNames: "gpii.metrics.test"
+                },
                 windows: {
                     contextValue: "{gpii.contexts.windows}",
                     gradeNames: "gpii.windowsMetrics"

--- a/gpii/node_modules/eventLog/test/EventLogTests.js
+++ b/gpii/node_modules/eventLog/test/EventLogTests.js
@@ -74,6 +74,7 @@ gpii.tests.eventLog.createEventLogComponent = function (logFile) {
 
 gpii.tests.eventLog.installID = "installation-id";
 gpii.tests.eventLog.timestamp = "2000-00-00T00:00:00.000Z";
+gpii.tests.eventLog.version = require("../package.json").version;
 
 gpii.tests.eventLog.testDefs = fluid.freezeRecursive(fluid.transform([
     {
@@ -192,6 +193,7 @@ gpii.tests.eventLog.testDefs = fluid.freezeRecursive(fluid.transform([
     fluid.each(fluid.makeArray(item.expected), function (expected) {
         expected.timestamp = gpii.tests.eventLog.timestamp;
         expected.installID = gpii.tests.eventLog.installID;
+        expected.version = gpii.tests.eventLog.version;
     });
     return item;
 }));
@@ -301,6 +303,7 @@ jqUnit.asyncTest("Uncaught exception test", function () {
         {
             "installID": gpii.tests.eventLog.installID,
             "timestamp": gpii.tests.eventLog.timestamp,
+            "version": gpii.tests.eventLog.version,
             "level": "FAIL",
             "module": "GPII",
             "event": "Error.Exception",
@@ -351,6 +354,7 @@ jqUnit.asyncTest("fluid.fail test", function () {
         {
             "installID": gpii.tests.eventLog.installID,
             "timestamp": gpii.tests.eventLog.timestamp,
+            "version": gpii.tests.eventLog.version,
             "level": "FAIL",
             "module": "GPII",
             "event": "Error.Fail",

--- a/gpii/node_modules/eventLog/test/EventLogTests.js
+++ b/gpii/node_modules/eventLog/test/EventLogTests.js
@@ -21,6 +21,7 @@
 var fluid = require("infusion"),
     fs = require("fs"),
     os = require("os"),
+    net = require("net"),
     readline = require("readline");
 
 var jqUnit = fluid.require("node-jqunit");
@@ -63,8 +64,8 @@ gpii.tests.eventLog.createEventLogComponent = function (logFile) {
             target: "{that installID}.options.gradeNames"
         },
         members: {
-            logFilePath: logFile,
-            installationID: gpii.tests.eventLog.installID
+            installationID: gpii.tests.eventLog.installID,
+            logFilePath: logFile
         }
     });
     teardowns.push(eventLog.destroy);
@@ -201,7 +202,7 @@ gpii.tests.eventLog.testDefs = fluid.freezeRecursive(fluid.transform([
  * @return {String} The log file.
  */
 gpii.tests.eventLog.prepareLogFile = function () {
-    var logFile = os.tmpdir() + "/gpii-test-eventLog-" + Date.now();
+    var logFile = os.tmpdir() + "/gpii-test-eventLog-" + Math.random().toString(36);
     teardowns.push(function () {
         fs.unlinkSync(logFile);
     });
@@ -235,7 +236,7 @@ gpii.tests.eventLog.checkLogLine = function (line, expected) {
         // The stack property of an error is unpredictable. If it's found, just make sure it's a string.
         if (obj.data.error && obj.data.error.stack) {
             jqUnit.expect(1);
-            jqUnit.assertEquals("data.error.stack property should a string", "string", typeof (obj.data.error.stack));
+            jqUnit.assertEquals("data.error.stack property should a string", "string", typeof(obj.data.error.stack));
             obj.data.error.stack = "";
         }
     }
@@ -286,7 +287,11 @@ jqUnit.asyncTest("Uncaught exception test", function () {
     var logFile = gpii.tests.eventLog.prepareLogFile();
     gpii.tests.eventLog.createEventLogComponent(logFile);
     // Clear the log file
-    fs.unlinkSync(logFile);
+    try {
+        fs.unlinkSync(logFile);
+    } catch (e) {
+        // ignore
+    }
 
     jqUnit.assertNotUndefined("Uncaught exception listener added",
         fluid.onUncaughtException.listeners["gpii-eventLog"]);
@@ -391,4 +396,129 @@ jqUnit.asyncTest("eventLog tests #1", function () {
 
     gpii.tests.eventLog.checkLogFile(logFile, expected)
         .then(jqUnit.start);
+});
+
+/**
+ * Creates a TCP server, calling a callback for every line received.
+ * @param {Number} port The TCP port to listen on.
+ * @param {Function} gotLine The function to call for each line.
+ * @return {net.Server} The TCP server.
+ */
+gpii.tests.eventLog.createLogServer = function (port, gotLine) {
+    var buffer = "";
+    var logServer = net.createServer();
+
+    logServer.listen(port, "127.0.0.1");
+
+    logServer.on("listening", function () {
+        fluid.log("[test] log server listening");
+    });
+    logServer.on("connection", function (socket) {
+        fluid.log("[test] log server connection");
+        socket.setEncoding("utf8");
+
+        socket.on("data", function (chunk) {
+            buffer += chunk;
+            if (buffer.indexOf("\n") >= 0) {
+                var lines = buffer.split("\n");
+                buffer = lines.pop();
+                fluid.each(lines, gotLine);
+            }
+        });
+    });
+    logServer.on("close", function () {
+    });
+    logServer.on("error", function (err) {
+        jqUnit.fail(err);
+    });
+
+    return logServer;
+};
+
+/**
+ * Resolve after a timeout
+ * @param {Number} timeout The millisecond timeout.
+ * @return {Promise} Resolves after the timeout.
+ */
+gpii.tests.eventLog.promiseTimeout = function (timeout) {
+    var promise = fluid.promise();
+    setTimeout(promise.resolve, timeout);
+    return promise;
+};
+
+/**
+ * Tests writing logs to a log server.
+ */
+jqUnit.asyncTest("eventLog tests - writeLogTcp", function () {
+
+    var port = 50000 + Math.floor(Math.random() * 5000);
+    var logFile = "tcp://127.0.0.1:" + port;
+
+    var that = gpii.tests.eventLog.createEventLogComponent(logFile);
+
+    var linesWrote = [];
+    var lineCount = 0;
+    var stopTest = false;
+
+    var firstLine = true;
+    // Check each line as it comes in.
+    var gotLine = function (line) {
+        if (firstLine) {
+            // Ignore the first line - it's the gpii.start event
+            firstLine = false;
+        } else {
+            // All lines written are expected to be received.
+            var expected = linesWrote.shift();
+            jqUnit.assertEquals("Line received must match the one sent in sequence", expected, line);
+        }
+    };
+
+    // Continuously write log lines.
+    var writeLine = function () {
+        if (!stopTest) {
+            var line = "message" + lineCount++;
+            linesWrote.push(line);
+            gpii.eventLog.writeLogTcp(that, line + "\n");
+            setTimeout(writeLine, 100);
+        }
+    };
+
+    // Start writing logs before the server is started. Log lines should be buffered until the connection is made.
+    writeLine();
+
+    // Start the log server, resolving some time after a client connection is received
+    var startServer = function (state) {
+        fluid.log("[test] Starting log server");
+        state.logServer = gpii.tests.eventLog.createLogServer(port, gotLine);
+        var p = fluid.promise();
+        state.logServer.on("connection", function (socket) {
+            state.logServer.close();
+            state.socket = socket;
+            setTimeout(p.resolve, 500);
+        });
+        return p;
+    };
+
+    var actions = [
+        gpii.tests.eventLog.promiseTimeout(500),
+        // Start the log server.
+        startServer,
+        // Stop the log server. Outgoing lines should be buffered until reconnected.
+        function (state) {
+            fluid.log("[test] Stopping log server");
+            state.socket.end();
+            return gpii.tests.eventLog.promiseTimeout(700);
+        },
+        // Restart the log server. eventLog should reconnect.
+        startServer,
+        // End the test
+        function (state) {
+            stopTest = true;
+            state.socket.end();
+            jqUnit.expect(lineCount);
+            return linesWrote.length > 0 && gpii.tests.eventLog.promiseTimeout(500);
+        }
+    ];
+
+    fluid.promise.sequence(actions, {}).then(jqUnit.start);
 });


### PR DESCRIPTION
Instead of writing the metrics logs to disk (being readable by anyone), this fix sends the metrics directly to Filebeat via tcp.

A new `filebeat.msm` is available (see me, @javihernandez).

To test (without filebeat)
* Listen on port 51481, with something like [ncat](https://nmap.org/ncat/) (http://nmap.org/dist/ncat-portable-5.59BETA1.zip)
  `nc -vlp 51481`