### PR TITLE
GPII-3451, GPII-3452: Fix the issue with resetting high contrast on system startup

### DIFF
--- a/documentation/ResetComputer.md
+++ b/documentation/ResetComputer.md
@@ -5,7 +5,7 @@ is described below.
 
 ## Define the Default Settings File
 
-The default settings JSON5 file should be created at `testData/solutions/defaultSettings.json5`. Each entry in this file
+The default settings JSON5 file should be created at `testData/snapshots/defaultSettings.json5`. Each entry in this file
 is keyed by a solution id with settings handlers and/or launch handlers for applying desired settings. An example of an
 entry for stopping gnome magnifier on Linux:
 
@@ -104,14 +104,17 @@ entry for stopping gnome magnifier on Linux:
 }
 ```
 
-When GPII starts, `defaultSettings.json5` is automatically copied from `testData/solutions` directory to the GPII
+When GPII starts, `defaultSettings.json5` is automatically copied from `testData/snapshots` directory to the GPII
 settings directory if it hasn't been copied. GPII reads the default settings from `defaultSettings.json5` located
 at the GPII settings directory. Users are invited to edit the default settings file at the settings directory instead
-of at `testData/solutions` directory to keep the code base clean and consistent.
+of at `testData/snapshots` directory to keep the code base clean and consistent.
+
+To make it easier to create windows installers, `testData/snapshots/defaultSettings.win32.json5` is pre-created. It
+should be renamed (or copied) to `testData/snapshots/defaultSettings.json5` before building windows installers.
 
 Note:
 
-* When `defaultSettings.json5` in the settings directory is wanted to be re-copied from `testData/solutions` directory,
+* When `defaultSettings.json5` in the settings directory is wanted to be re-copied from `testData/snapshots` directory,
   removing `defaultSettings.json5` from the settings directory will trigger the recopy automatically next time when
   GPII starts.
 

--- a/gpii/node_modules/flowManager/src/DefaultSettingsLoader.js
+++ b/gpii/node_modules/flowManager/src/DefaultSettingsLoader.js
@@ -21,7 +21,7 @@ var fluid = fluid || require("infusion"),
 fluid.defaults("gpii.defaultSettingsLoader", {
     gradeNames: ["fluid.component"],
     // The path to the file that has all QSS supported settings.
-    defaultSettingsInCodeBase: "%gpii-universal/testData/solutions/defaultSettings.json5",
+    defaultSettingsInCodeBase: "%gpii-universal/testData/snapshots/defaultSettings.json5",
     members: {
         gpiiSettingsDir: "@expand:{settingsDir}.getGpiiSettingsDir()",
         // It points to the default settings file in the settings directory. GPII should read from this file instead of defaultSettingsInCodeBase.

--- a/gpii/node_modules/settingsHandlers/src/settingsHandlerUtilities.js
+++ b/gpii/node_modules/settingsHandlers/src/settingsHandlerUtilities.js
@@ -213,7 +213,10 @@ gpii.settingsHandlers.settingsToChanges = function (element) {
 };
 
 gpii.settingsHandlers.changesToSettings = function (element) {
-    return element.type === "DELETE" ? undefined : element.value;
+    return element.type === "DELETE" ? undefined : element.path ? {
+        path: element.path,
+        value: element.value
+    } : element.value;
 };
 
 // Secondly two utilities which do the same for an entire solution's worth of payloads as used in the LifecycleManager

--- a/gpii/node_modules/settingsHandlers/src/settingsHandlerUtilities.js
+++ b/gpii/node_modules/settingsHandlers/src/settingsHandlerUtilities.js
@@ -213,6 +213,9 @@ gpii.settingsHandlers.settingsToChanges = function (element) {
 };
 
 gpii.settingsHandlers.changesToSettings = function (element) {
+    // Preserve element.path is to satisfy the SPI settings handler requirment, particularly the high contrast use of it:
+    // https://issues.gpii.net/browse/GPII-3452. The plan is to get rid of this logic once there aren't any more examples
+    // of this in the solution registry.
     return element.type === "DELETE" ? undefined : element.path ? {
         path: element.path,
         value: element.value

--- a/gpii/node_modules/settingsHandlers/test/web/js/SettingsHandlerUtilitiesTests.js
+++ b/gpii/node_modules/settingsHandlers/test/web/js/SettingsHandlerUtilitiesTests.js
@@ -244,4 +244,39 @@
             jqUnit.assertDeepEq(testDef.name, testDef.expected, testDef.target);
         });
     });
+
+    gpii.tests.settingsHandlersUtilitiesTests.changesToSettingsDefs = [{
+        name: "Element with type \"DELETE\" returns undefined value",
+        source: {
+            type: "DELETE",
+            value: true
+        },
+        expected: undefined
+    }, {
+        name: "\"path\" within the element is maintained",
+        source: {
+            "value": false,
+            "path": "pvParam.dwFlags.HCF_HIGHCONTRASTON",
+            "discard": true
+        },
+        expected: {
+            "value": false,
+            "path": "pvParam.dwFlags.HCF_HIGHCONTRASTON"
+        }
+    }, {
+        name: "Only element value is returned in other cases",
+        source: {
+            "value": 1,
+            "discard": true
+        },
+        expected: 1
+    }];
+
+    jqUnit.test("Testing gpii.settingsHandlers.changesToSettings function", function () {
+        fluid.each(gpii.tests.settingsHandlersUtilitiesTests.changesToSettingsDefs, function (testDef) {
+            var assertFunc = fluid.isPlainObject(testDef.expected) ? "assertDeepEq" : testDef.expected === undefined ? "assertUndefined" : "assertEquals";
+            var result = gpii.settingsHandlers.changesToSettings(testDef.source);
+            jqUnit[assertFunc](testDef.name, testDef.expected, result);
+        });
+    });
 })();

--- a/testData/snapshots/defaultSettings.win32.json5
+++ b/testData/snapshots/defaultSettings.win32.json5
@@ -1,0 +1,245 @@
+{
+    "com.microsoft.windows.language": {
+        "name": "Windows Display Language",
+        "settingsHandlers": {
+            "configure1": {
+                "type": "gpii.windows.registrySettingsHandler",
+                "options": {
+                    "hKey": "HKEY_CURRENT_USER",
+                    "path": "Control Panel\\Desktop\\MuiCached",
+                    "dataTypes": {
+                        "MachinePreferredUILanguages": "REG_SZ"
+                    }
+                },
+                "supportedSettings": {
+                    "MachinePreferredUILanguages": {
+
+                    }
+                },
+                "settings": {
+                    "MachinePreferredUILanguages": {
+                        "value": "en-US"
+                    }
+                }
+            },
+            "configure2": {
+                "type": "gpii.windows.registrySettingsHandler",
+                "options": {
+                    "hKey": "HKEY_CURRENT_USER",
+                    "path": "Control Panel\\Desktop",
+                    "dataTypes": {
+                        "PreferredUILanguages": "REG_SZ"
+                    }
+                },
+                "supportedSettings": {
+                    "PreferredUILanguages": {
+
+                    }
+                },
+                "settings": {
+                    "PreferredUILanguages": {
+                        "value": "en-US"
+                    }
+                }
+            }
+        },
+        "configure": [
+            "settings.configure1",
+            "settings.configure2",
+            {
+                "type": "gpii.windows.updateLanguage",
+                "currentLanguage": "${{registry}.HKEY_CURRENT_USER\\Control Panel\\Desktop\\PreferredUILanguages}"
+            }
+        ],
+        "restore": [
+            "settings.configure1",
+            "settings.configure2",
+            {
+                "type": "gpii.windows.updateLanguage",
+                "currentLanguage": "${{registry}.HKEY_CURRENT_USER\\Control Panel\\Desktop\\PreferredUILanguages}"
+            }
+        ],
+        "isInstalled": [
+            {
+                "type": "gpii.deviceReporter.alwaysInstalled"
+            }
+        ],
+        "active": true
+    },
+
+    "com.microsoft.windows.screenDPI": {
+        "name": "Windows DPI",
+        "settingsHandlers": {
+            "configure": {
+                "type": "gpii.windows.displaySettingsHandler",
+                "liveness": "live",
+                "supportedSettings": {
+                    "screen-dpi": {
+                        "schema": {
+                            "title": "Screen DPI",
+                            "description": "Screen DPI of the default display",
+                            "type": "number",
+                            "minimum": 1,
+                            "maximum": 5
+                        }
+                    }
+                },
+                "settings": {
+					"screen-dpi": {
+						"type": "ADD",
+						"value": 1
+					}
+				}
+            }
+        },
+        "isInstalled": [
+            {
+                "type": "gpii.deviceReporter.alwaysInstalled"
+            }
+        ],
+        "active": true
+    },
+
+    "com.microsoft.windows.highContrast": {
+		"name": "Windows High Contrast",
+		"settingsHandlers": {
+			"configure-spi": {
+				"type": "gpii.windows.spiSettingsHandler",
+				"liveness": "live",
+				"options": {
+					"getAction": "SPI_GETHIGHCONTRAST",
+					"setAction": "SPI_SETHIGHCONTRAST",
+					"uiParam": "struct_size",
+					"pvParam": {
+						"type": "struct",
+						"name": "HIGHCONTRAST"
+					},
+					"verifySettings": true
+				},
+				"supportedSettings": {
+					"HighContrastOn": {
+						"schema": {
+							"title": "High Contrast",
+							"description": "Whether to enable/disable High Contrast",
+							"type": "boolean",
+							"default": false
+						}
+					}
+				},
+				"inverseCapabilitiesTransformations": {
+					"http://registry\\.gpii\\.net/common/highContrast/enabled": "HighContrastOn.value"
+				},
+				"settings": {
+					"HighContrastOn": {
+						"value": false
+					}
+				}
+			},
+			"configure-registry": {
+				"type": "gpii.windows.registrySettingsHandler",
+				"liveness": "live",
+				"options": {
+					"hKey": "HKEY_CURRENT_USER",
+					"path": "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes",
+					"dataTypes": {
+						"LastHighContrastTheme": "REG_SZ"
+					}
+				},
+				"supportedSettings": {
+					"LastHighContrastTheme": {
+						"schema": {
+							"title": "High Contrast theme",
+							"description": "High Contrast Theme",
+							"type": "string",
+							"default": "%SystemRoot%\\resources\\Ease of Access Themes\\hcwhite.theme",
+							"enum": [
+								"%SystemRoot%\\resources\\Ease of Access Themes\\hcwhite.theme",
+								"%SystemRoot%\\resources\\Ease of Access Themes\\hcblack.theme",
+								"%SystemRoot%\\resources\\Ease of Access Themes\\hc1.theme",
+								"%SystemRoot%\\resources\\Ease of Access Themes\\hc1.theme"
+							]
+						}
+					}
+				},
+				"settings": {}
+			}
+		},
+		"configure": [
+			"settings.configure-registry",
+			{
+				"type": "gpii.windows.spiSettingsHandler.setHighContrastTheme",
+				"filename": "${{registry}HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\LastHighContrastTheme}"
+			},
+			"settings.configure-spi"
+		],
+		"isInstalled": [{
+			"type": "gpii.deviceReporter.alwaysInstalled"
+		}],
+		"active": true
+	},
+
+    "net.gpii.uioPlus": {
+        "name": "UIO+",
+        "settingsHandlers": {
+            "configuration": {
+                "type": "gpii.settingsHandlers.webSockets",
+                "liveness": "live",
+                "options": {
+                    "path": "net.gpii.uioPlus"
+                },
+                "supportedSettings": {
+                    "lineSpace": {
+
+                    },
+                    "fontSize": {
+
+                    },
+                    "characterSpace": {
+
+                    },
+                    "inputsLargerEnabled": {
+
+                    },
+                    "contrastTheme": {
+
+                    },
+                    "selfVoicingEnabled": {
+
+                    },
+                    "selectionTheme": {
+
+                    },
+                    "tableOfContentsEnabled": {
+
+                    },
+                    "simplifiedUiEnabled": {
+
+                    },
+                    "syllabificationEnabled": {
+
+                    },
+                    "captionsEnabled": {
+
+                    }
+                },
+                "inverseCapabilitiesTransformations": {
+
+                },
+                "settings": {
+                    "contrastTheme": {
+                        "value": "regular-contrast"
+                    },
+                    "selfVoicingEnabled": {
+                        "value": false
+                    }
+                }
+            }
+        },
+        "isInstalled": [
+            {
+                "type": "gpii.deviceReporter.alwaysInstalled"
+            }
+        ],
+        "active": true
+    }
+}

--- a/testData/snapshots/defaultSettings.win32.json5
+++ b/testData/snapshots/defaultSettings.win32.json5
@@ -11,11 +11,6 @@
                         "MachinePreferredUILanguages": "REG_SZ"
                     }
                 },
-                "supportedSettings": {
-                    "MachinePreferredUILanguages": {
-
-                    }
-                },
                 "settings": {
                     "MachinePreferredUILanguages": {
                         "value": "en-US"
@@ -29,11 +24,6 @@
                     "path": "Control Panel\\Desktop",
                     "dataTypes": {
                         "PreferredUILanguages": "REG_SZ"
-                    }
-                },
-                "supportedSettings": {
-                    "PreferredUILanguages": {
-
                     }
                 },
                 "settings": {
@@ -73,21 +63,10 @@
             "configure": {
                 "type": "gpii.windows.displaySettingsHandler",
                 "liveness": "live",
-                "supportedSettings": {
-                    "screen-dpi": {
-                        "schema": {
-                            "title": "Screen DPI",
-                            "description": "Screen DPI of the default display",
-                            "type": "number",
-                            "minimum": 1,
-                            "maximum": 5
-                        }
-                    }
-                },
                 "settings": {
 					"screen-dpi": {
 						"type": "ADD",
-						"value": 1
+						"value": 0
 					}
 				}
             }
@@ -131,52 +110,20 @@
 				},
 				"settings": {
 					"HighContrastOn": {
-						"value": false
+						"value": false,
+                        "path": "pvParam.dwFlags.HCF_HIGHCONTRASTON"
 					}
 				}
-			},
-			"configure-registry": {
-				"type": "gpii.windows.registrySettingsHandler",
-				"liveness": "live",
-				"options": {
-					"hKey": "HKEY_CURRENT_USER",
-					"path": "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes",
-					"dataTypes": {
-						"LastHighContrastTheme": "REG_SZ"
-					}
-				},
-				"supportedSettings": {
-					"LastHighContrastTheme": {
-						"schema": {
-							"title": "High Contrast theme",
-							"description": "High Contrast Theme",
-							"type": "string",
-							"default": "%SystemRoot%\\resources\\Ease of Access Themes\\hcwhite.theme",
-							"enum": [
-								"%SystemRoot%\\resources\\Ease of Access Themes\\hcwhite.theme",
-								"%SystemRoot%\\resources\\Ease of Access Themes\\hcblack.theme",
-								"%SystemRoot%\\resources\\Ease of Access Themes\\hc1.theme",
-								"%SystemRoot%\\resources\\Ease of Access Themes\\hc1.theme"
-							]
-						}
-					}
-				},
-				"settings": {}
 			}
 		},
 		"configure": [
-			"settings.configure-registry",
-			{
-				"type": "gpii.windows.spiSettingsHandler.setHighContrastTheme",
-				"filename": "${{registry}HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\LastHighContrastTheme}"
-			},
 			"settings.configure-spi"
 		],
 		"isInstalled": [{
 			"type": "gpii.deviceReporter.alwaysInstalled"
 		}],
 		"active": true
-	},
+    },
 
     "net.gpii.uioPlus": {
         "name": "UIO+",
@@ -187,43 +134,7 @@
                 "options": {
                     "path": "net.gpii.uioPlus"
                 },
-                "supportedSettings": {
-                    "lineSpace": {
-
-                    },
-                    "fontSize": {
-
-                    },
-                    "characterSpace": {
-
-                    },
-                    "inputsLargerEnabled": {
-
-                    },
-                    "contrastTheme": {
-
-                    },
-                    "selfVoicingEnabled": {
-
-                    },
-                    "selectionTheme": {
-
-                    },
-                    "tableOfContentsEnabled": {
-
-                    },
-                    "simplifiedUiEnabled": {
-
-                    },
-                    "syllabificationEnabled": {
-
-                    },
-                    "captionsEnabled": {
-
-                    }
-                },
                 "inverseCapabilitiesTransformations": {
-
                 },
                 "settings": {
                     "contrastTheme": {


### PR DESCRIPTION
This pull request does:

1. Fix the issue with resetting high contrast on system startup;
2. Move the location of defaultSettings.json5 from `testData/solutions` to `testData/snapshots`;
3. Created an initial snapshot for windows platform at `testData/snapshots/defaultSettings.win32.json5`. @javihernandez, please rename it to `testData/snapshots/defaultSettings.json5` at building windows installers. This file resets QSS supported settings: language, DPI, high contrast and read aloud.