### PR TITLE
Dataloader move to universal from gpii-ops/gpii-dataloader

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 COPY . /app
 
 RUN apk add --no-cache --virtual build-dependencies python make git g++ && \
+    apk add --no-cache curl jq && \
     npm install && \
     chown -R node:node . && \
     npm cache clean --force && \

--- a/documentation/DataLoader.md
+++ b/documentation/DataLoader.md
@@ -1,22 +1,21 @@
 # CouchDB Data Loader
+(`scripts/deleteAndLoadSnapsets.sh`)
 
-Builds a [sidecar container](http://blog.kubernetes.io/2015/06/the-distributed-system-toolkit-patterns.html) that contains the `git` command and a shell script for setting up a CouchDB database.  When the docker image is run, this sequence is executed:
-1. Clones the latest version of [GPII universal](https://github.com/gpii/universal/),
+This script is used to setup CouchDB database and is executed as a Kubernetes
+batch Job every time new version of the universal image is deployed to the
+cluster (also when cluster is initially created).
+
+It does following:
 1. Converts the preferences in universal into `snapset` Prefs Safes and GPII Keys,
+1. Optionally deletes existing database,
 1. Creates a CouchDB database if none exits,
-1. Optionally clears an existing database of all its records,
 1. Updates the database with respect to its `design/views` document, as required,
-1. Deletes any snapsets currently in the database,
-1. Loads the latest snapsets created at the second step into the database.
-
-## Building
-
-- `docker build -t gpii/gpii-dataloader .`
+1. Loads the latest snapsets created into the database.
 
 ## Environment Variables
 
 - `COUCHDB_URL`: URL of the CouchDB database. (required)
-- `CLEAR_INDEX`: If defined, the database at $COUCHDB_URL will be deleted and recreated. (optional)
+- `CLEAR_INDEX`: If set to `true`, the database at $COUCHDB_URL will be deleted and recreated. (optional)
 - `STATIC_DATA_DIR`: The directory where the static data to be loaded into CouchDB resides. (optional)
 - `BUILD_DATA_DIR`: The directory where the data built from the conversion step resides. (optional)
 
@@ -30,19 +29,19 @@ Example using containers:
 
 ```
 $ docker run -d -p 5984:5984 --name couchdb couchdb
-$ docker run --rm --link couchdb -e COUCHDB_URL=http://couchdb:5984/gpii -e CLEAR_INDEX=1 gpii/gpii-dataloader
+$ docker run --rm --link couchdb -e COUCHDB_URL=http://couchdb:5984/gpii -e CLEAR_INDEX=true vagrant-universal scripts/deleteAndLoadSnapsets.sh
 $ docker run -d -p 8081:8081 --name preferences --link couchdb -e NODE_ENV=gpii.config.preferencesServer.standalone.production  -e PREFERENCESSERVER_LISTEN_PORT=8081 -e DATASOURCE_HOSTNAME=http://couchdb -e DATASOURCE_PORT=5984 vagrant-universal
 
 ```
 
-Below are two versions of loading couchdb data from a different location (e.g. /home/vagrant/sync/universal/testData/dbData for static data directory and /home/vagrant/sync/universal/build/dbData for build data directory).  The first version has the optional `CLEAR_INDEX` set to erase and reset the database prior to other database changes:
+Below are two versions of loading couchdb data from a different location (e.g. /home/vagrant/sync/universal/testData/dbData for static data directory and /home/vagrant/sync/universal/build/dbData for build data directory).  The first version has the optional `CLEAR_INDEX` set to true to erase and reset the database prior to other database changes:
 
 ```
-$ docker run --name dataloader --link couchdb -v /home/vagrant/sync/universal/testData/dbData:/static_data -e STATIC_DATA_DIR=/static_data -v /home/vagrant/sync/universal/build/dbData:/build_data -e BUILD_DATA_DIR=/build_data -e COUCHDB_URL=http://couchdb:5984/gpii -e CLEAR_INDEX=1 gpii/gpii-dataloader
+$ docker run --name dataloader --link couchdb -v /home/vagrant/sync/universal/testData/dbData:/static_data -e STATIC_DATA_DIR=/static_data -v /home/vagrant/sync/universal/build/dbData:/build_data -e BUILD_DATA_DIR=/build_data -e COUCHDB_URL=http://couchdb:5984/gpii -e CLEAR_INDEX=true vagrant-universal scripts/deleteAndLoadSnapsets.sh
 ```
 
-The second version has `CLEAR_INDEX` set to nothing such that any existing database is left intact prior to subsequent changes to it (e.g., deleting the snapsets):
+The second version does not set `CLEAR_INDEX` such that any existing database is left intact prior to subsequent changes to it (e.g., deleting the snapsets):
 
 ```
-$ docker run --name dataloader --link couchdb -v /home/vagrant/sync/universal/testData/dbData:/static_data -e STATIC_DATA_DIR=/static_data -v /home/vagrant/sync/universal/build/dbData:/build_data -e BUILD_DATA_DIR=/build_data -e COUCHDB_URL=http://couchdb:5984/gpii -e CLEAR_INDEX= gpii/gpii-dataloader
+$ docker run --name dataloader --link couchdb -v /home/vagrant/sync/universal/testData/dbData:/static_data -e STATIC_DATA_DIR=/static_data -v /home/vagrant/sync/universal/build/dbData:/build_data -e BUILD_DATA_DIR=/build_data -e COUCHDB_URL=http://couchdb:5984/gpii vagrant-universal scripts/deleteAndLoadSnapsets.sh
 ```

--- a/documentation/DataLoader.md
+++ b/documentation/DataLoader.md
@@ -1,0 +1,48 @@
+# CouchDB Data Loader
+
+Builds a [sidecar container](http://blog.kubernetes.io/2015/06/the-distributed-system-toolkit-patterns.html) that contains the `git` command and a shell script for setting up a CouchDB database.  When the docker image is run, this sequence is executed:
+1. Clones the latest version of [GPII universal](https://github.com/gpii/universal/),
+1. Converts the preferences in universal into `snapset` Prefs Safes and GPII Keys,
+1. Creates a CouchDB database if none exits,
+1. Optionally clears an existing database of all its records,
+1. Updates the database with respect to its `design/views` document, as required,
+1. Deletes any snapsets currently in the database,
+1. Loads the latest snapsets created at the second step into the database.
+
+## Building
+
+- `docker build -t gpii/gpii-dataloader .`
+
+## Environment Variables
+
+- `COUCHDB_URL`: URL of the CouchDB database. (required)
+- `CLEAR_INDEX`: If defined, the database at $COUCHDB_URL will be deleted and recreated. (optional)
+- `STATIC_DATA_DIR`: The directory where the static data to be loaded into CouchDB resides. (optional)
+- `BUILD_DATA_DIR`: The directory where the data built from the conversion step resides. (optional)
+
+The use of environment variables for data directories is useful if you want to mount the database data using a Docker volume and point the data loader at it.
+
+Note that since [the docker doesn't support the environment variable type of array](https://github.com/moby/moby/issues/20169), two separate environment variables are used for inputting data directories instead of one array that holds these directories.
+
+## Running
+
+Example using containers:
+
+```
+$ docker run -d -p 5984:5984 --name couchdb couchdb
+$ docker run --rm --link couchdb -e COUCHDB_URL=http://couchdb:5984/gpii -e CLEAR_INDEX=1 gpii/gpii-dataloader
+$ docker run -d -p 8081:8081 --name preferences --link couchdb -e NODE_ENV=gpii.config.preferencesServer.standalone.production  -e PREFERENCESSERVER_LISTEN_PORT=8081 -e DATASOURCE_HOSTNAME=http://couchdb -e DATASOURCE_PORT=5984 vagrant-universal
+
+```
+
+Below are two versions of loading couchdb data from a different location (e.g. /home/vagrant/sync/universal/testData/dbData for static data directory and /home/vagrant/sync/universal/build/dbData for build data directory).  The first version has the optional `CLEAR_INDEX` set to erase and reset the database prior to other database changes:
+
+```
+$ docker run --name dataloader --link couchdb -v /home/vagrant/sync/universal/testData/dbData:/static_data -e STATIC_DATA_DIR=/static_data -v /home/vagrant/sync/universal/build/dbData:/build_data -e BUILD_DATA_DIR=/build_data -e COUCHDB_URL=http://couchdb:5984/gpii -e CLEAR_INDEX=1 gpii/gpii-dataloader
+```
+
+The second version has `CLEAR_INDEX` set to nothing such that any existing database is left intact prior to subsequent changes to it (e.g., deleting the snapsets):
+
+```
+$ docker run --name dataloader --link couchdb -v /home/vagrant/sync/universal/testData/dbData:/static_data -e STATIC_DATA_DIR=/static_data -v /home/vagrant/sync/universal/build/dbData:/build_data -e BUILD_DATA_DIR=/build_data -e COUCHDB_URL=http://couchdb:5984/gpii -e CLEAR_INDEX= gpii/gpii-dataloader
+```

--- a/documentation/DataLoader.md
+++ b/documentation/DataLoader.md
@@ -1,16 +1,17 @@
 # CouchDB Data Loader
+
 (`scripts/deleteAndLoadSnapsets.sh`)
 
-This script is used to setup CouchDB database and is executed as a Kubernetes
-batch Job every time new version of the universal image is deployed to the
-cluster (also when cluster is initially created).
+This script is used to setup CouchDB database and is executed as a Kubernetes batch Job every time new version of the
+universal image is deployed to the cluster (also when cluster is initially created).
 
 It does following:
-1. Converts the preferences in universal into `snapset` Prefs Safes and GPII Keys,
-1. Optionally deletes existing database,
-1. Creates a CouchDB database if none exits,
-1. Updates the database with respect to its `design/views` document, as required,
-1. Loads the latest snapsets created into the database.
+
+- Converts the preferences in universal into `snapset` Prefs Safes and GPII Keys,
+- Optionally deletes existing database,
+- Creates a CouchDB database if none exits,
+- Updates the database with respect to its `design/views` document, as required,
+- Loads the latest snapsets created into the database.
 
 ## Environment Variables
 
@@ -19,29 +20,47 @@ It does following:
 - `STATIC_DATA_DIR`: The directory where the static data to be loaded into CouchDB resides. (optional)
 - `BUILD_DATA_DIR`: The directory where the data built from the conversion step resides. (optional)
 
-The use of environment variables for data directories is useful if you want to mount the database data using a Docker volume and point the data loader at it.
+The use of environment variables for data directories is useful if you want to mount the database data using a Docker
+volume and point the data loader at it.
 
-Note that since [the docker doesn't support the environment variable type of array](https://github.com/moby/moby/issues/20169), two separate environment variables are used for inputting data directories instead of one array that holds these directories.
+Note that since [the docker doesn't support the environment variable type of
+array](https://github.com/moby/moby/issues/20169), two separate environment variables are used for inputting data
+directories instead of one array that holds these directories.
 
 ## Running
 
 Example using containers:
 
-```
+```bash
 $ docker run -d -p 5984:5984 --name couchdb couchdb
-$ docker run --rm --link couchdb -e COUCHDB_URL=http://couchdb:5984/gpii -e CLEAR_INDEX=true vagrant-universal scripts/deleteAndLoadSnapsets.sh
-$ docker run -d -p 8081:8081 --name preferences --link couchdb -e NODE_ENV=gpii.config.preferencesServer.standalone.production  -e PREFERENCESSERVER_LISTEN_PORT=8081 -e DATASOURCE_HOSTNAME=http://couchdb -e DATASOURCE_PORT=5984 vagrant-universal
-
+$ docker run --rm --link couchdb -e COUCHDB_URL=http://couchdb:5984/gpii \
+    -e CLEAR_INDEX=true vagrant-universal scripts/deleteAndLoadSnapsets.sh
+$ docker run -d -p 8081:8081 --name preferences --link couchdb \
+    -e NODE_ENV=gpii.config.preferencesServer.standalone.production \
+    -e PREFERENCESSERVER_LISTEN_PORT=8081 -e DATASOURCE_HOSTNAME=http://couchdb \
+    -e DATASOURCE_PORT=5984 vagrant-universal
 ```
 
-Below are two versions of loading couchdb data from a different location (e.g. /home/vagrant/sync/universal/testData/dbData for static data directory and /home/vagrant/sync/universal/build/dbData for build data directory).  The first version has the optional `CLEAR_INDEX` set to true to erase and reset the database prior to other database changes:
+Below are two versions of loading couchdb data from a different location (e.g.
+/home/vagrant/sync/universal/testData/dbData for static data directory and /home/vagrant/sync/universal/build/dbData for
+build data directory).  The first version has the optional `CLEAR_INDEX` set to true to erase and reset the database
+prior to other database changes:
 
-```
-$ docker run --name dataloader --link couchdb -v /home/vagrant/sync/universal/testData/dbData:/static_data -e STATIC_DATA_DIR=/static_data -v /home/vagrant/sync/universal/build/dbData:/build_data -e BUILD_DATA_DIR=/build_data -e COUCHDB_URL=http://couchdb:5984/gpii -e CLEAR_INDEX=true vagrant-universal scripts/deleteAndLoadSnapsets.sh
+```bash
+$ docker run --name dataloader --link couchdb \
+    -v /home/vagrant/sync/universal/testData/dbData:/static_data -e STATIC_DATA_DIR=/static_data \
+    -v /home/vagrant/sync/universal/build/dbData:/build_data -e BUILD_DATA_DIR=/build_data \
+    -e COUCHDB_URL=http://couchdb:5984/gpii \
+    -e CLEAR_INDEX=true vagrant-universal scripts/deleteAndLoadSnapsets.sh
 ```
 
-The second version does not set `CLEAR_INDEX` such that any existing database is left intact prior to subsequent changes to it (e.g., deleting the snapsets):
+The second version does not set `CLEAR_INDEX` such that any existing database is left intact prior to subsequent changes
+to it (e.g., deleting the snapsets):
 
-```
-$ docker run --name dataloader --link couchdb -v /home/vagrant/sync/universal/testData/dbData:/static_data -e STATIC_DATA_DIR=/static_data -v /home/vagrant/sync/universal/build/dbData:/build_data -e BUILD_DATA_DIR=/build_data -e COUCHDB_URL=http://couchdb:5984/gpii vagrant-universal scripts/deleteAndLoadSnapsets.sh
+```bash
+$ docker run --name dataloader --link couchdb \
+    -v /home/vagrant/sync/universal/testData/dbData:/static_data -e STATIC_DATA_DIR=/static_data \
+    -v /home/vagrant/sync/universal/build/dbData:/build_data -e BUILD_DATA_DIR=/build_data \
+    -e COUCHDB_URL=http://couchdb:5984/gpii \
+    vagrant-universal scripts/deleteAndLoadSnapsets.sh
 ```

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -9,6 +9,7 @@
   * [Preferences Server](PreferencesServer.md)
 * [Data Model for Preferences and OAuth Data](DataModel.md)
   * [Pouch Manager](PouchManager.md)
+  * [Data Loader](DataLoader.md)
 * [MatchMakerFramework](MatchMakerFramework.md)
   * [Flat Match Maker](FlatMatchMaker.md)
   * [Apptology](Apptology.md)

--- a/scripts/convertPrefs.js
+++ b/scripts/convertPrefs.js
@@ -45,7 +45,7 @@ rimraf(targetDir, function () {
         filenames.forEach(function (filename) {
             if (filename.endsWith(".json5")) {
                 var gpiiKey = filename.substr(0, filename.length - 6);
-                var preferences = fs.readFileSync(inputDir + filename, "utf-8");
+                var preferences = fs.readFileSync(inputDir + "/" + filename, "utf-8");
                 var currentTime = new Date().toISOString();
                 var prefsSafeId = "prefsSafe-" + gpiiKey;
 
@@ -80,11 +80,11 @@ rimraf(targetDir, function () {
         });
 
         // Write the target files
-        var prefsSafesFile = targetDir + "prefsSafes.json";
+        var prefsSafesFile = targetDir + "/prefsSafes.json";
         console.log("prefsSafesFile: " + prefsSafesFile);
         fs.writeFileSync(prefsSafesFile, JSON.stringify(prefsSafes, null, 4));
 
-        var gpiiKeysFile = targetDir + "gpiiKeys.json";
+        var gpiiKeysFile = targetDir + "/gpiiKeys.json";
         fs.writeFileSync(gpiiKeysFile, JSON.stringify(gpiiKeys, null, 4));
 
         console.log("Finished converting preferences data in the source directory " + inputDir + " to the target directory " + targetDir);

--- a/scripts/deleteAndLoadSnapsets.sh
+++ b/scripts/deleteAndLoadSnapsets.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+STATIC_DATA_DIR=${STATIC_DATA_DIR:-/home/node/universal/testData/dbData}
+BUILD_DATA_DIR=${BUILD_DATA_DIR:-/home/node/universal/build/dbData/snapset}
+
+log() {
+  echo "$(date +'%Y-%m-%d %H:%M:%S') - $1"
+}
+
+warm_indices(){
+  log "Warming indices..."
+
+  for view in $(curl -s $COUCHDB_URL/_design/views/ | jq -r '.views | keys[]'); do
+    curl -fsS $COUCHDB_URL/_design/views/_view/$view >/dev/null
+  done
+
+  log "Finished warming indices..."
+}
+
+# Verify variables
+if [ -z "$COUCHDB_URL" ]; then
+  echo "COUCHDB_URL environment variable must be defined"
+  exit 1
+fi
+
+if [ ! -d "$STATIC_DATA_DIR" -o ! "$(ls -A $STATIC_DATA_DIR/*.json)" ]; then
+  echo "STATIC_DATA_DIR ($STATIC_DATA_DIR) does not exist or does not contain data, using universal's 'testData/dbData' as the default"
+  STATIC_DATA_DIR=./testData/dbData
+fi
+
+if [ ! -d "$BUILD_DATA_DIR" -o ! "$(ls -A $BUILD_DATA_DIR/*.json)" ]; then
+  echo "BUILD_DATA_DIR ($BUILD_DATA_DIR) does not exist or does not contain data, using universal's 'build/dbData/snapset' as the default"
+  BUILD_DATA_DIR=./build/dbData/snapset
+fi
+
+COUCHDB_URL_SANITIZED=`echo "$COUCHDB_URL" | sed -e 's,\(://\)[^/]*\(@\),\1<SENSITIVE>\2,g'`
+
+log "Starting"
+log "CouchDB: $COUCHDB_URL_SANITIZED"
+log "Clear index: $CLEAR_INDEX"
+log "Static: $STATIC_DATA_DIR"
+log "Build: $BUILD_DATA_DIR"
+log "Working directory: `pwd`"
+
+# Set up universal
+git clone --depth 1 https://github.com/GPII/universal.git
+cd universal
+
+npm install json5
+npm install fs
+npm install rimraf
+npm install mkdirp
+npm install infusion
+rm -f package-lock.json
+node scripts/convertPrefs.js testData/preferences/ build/dbData/snapset/ snapset
+
+# Initialize (possibly clear) data base
+if [ ! -z "$CLEAR_INDEX" ]; then
+  log "Deleting database at $COUCHDB_URL_SANITIZED"
+  if ! curl -fsS -X DELETE "$COUCHDB_URL"; then
+    log "Error deleting database"
+  fi
+fi
+
+log "Creating database at $COUCHDB_URL_SANITIZED"
+if ! curl -fsS -X PUT "$COUCHDB_URL"; then
+  log "Database already exists at $COUCHDB_URL_SANITIZED"
+fi
+
+# Submit data
+node scripts/deleteAndLoadSnapsets.js $COUCHDB_URL $STATIC_DATA_DIR $BUILD_DATA_DIR
+err=$?
+if [ $err != 0 ]; then
+  log "deleteAndLoadSnapsets.js failed with $err, exiting"
+  exit $err
+fi
+
+# Warm Data
+warm_indices

--- a/scripts/deleteAndLoadSnapsets.sh
+++ b/scripts/deleteAndLoadSnapsets.sh
@@ -28,15 +28,6 @@ if [ -z "$COUCHDB_URL" ]; then
   exit 1
 fi
 
-if [ ! -d "$STATIC_DATA_DIR" -o ! "$(ls -A $STATIC_DATA_DIR/*.json)" ]; then
-  echo "STATIC_DATA_DIR ($STATIC_DATA_DIR) does not exist or does not contain data, using universal's 'testData/dbData' as the default"
-  STATIC_DATA_DIR=./testData/dbData
-fi
-
-if [ ! -d "$BUILD_DATA_DIR" -o ! "$(ls -A $BUILD_DATA_DIR/*.json)" ]; then
-  echo "BUILD_DATA_DIR ($BUILD_DATA_DIR) does not exist or does not contain data, using universal's 'build/dbData/snapset' as the default"
-  BUILD_DATA_DIR=./build/dbData/snapset
-fi
 
 COUCHDB_URL_SANITIZED=`echo "$COUCHDB_URL" | sed -e 's,\(://\)[^/]*\(@\),\1<SENSITIVE>\2,g'`
 
@@ -47,6 +38,10 @@ log "Static: $STATIC_DATA_DIR"
 log "Build: $BUILD_DATA_DIR"
 log "Working directory: `pwd`"
 
+# Create build dir if it does not exist
+if [ ! -d "${BUILD_DATA_DIR}" ]; then
+  mkdir -p "${BUILD_DATA_DIR}"
+fi
 
 # Convert preferences json5 to GPII keys and preferences safes
 if [ -d "${PREFERENCES_DATA_DIR}" ]; then

--- a/scripts/deleteAndLoadSnapsets.sh
+++ b/scripts/deleteAndLoadSnapsets.sh
@@ -37,6 +37,13 @@ log "Static: ${STATIC_DATA_DIR}"
 log "Build: ${BUILD_DATA_DIR}"
 log "Working directory: $(pwd)"
 
+# Check we can connect to CouchDB
+COUCHDB_URL_ROOT=$(echo "${COUCHDB_URL}" | sed 's/[^\/]*$//g')
+RET_CODE=$(curl --write-out '%{http_code}' --silent --output /dev/null "${COUCHDB_URL_ROOT}/_up")
+if [ "$RET_CODE" != '200' ]; then
+  log "[ERROR] Failed to connect to CouchDB: ${COUCHDB_URL_SANITIZED}"
+  exit 1
+fi
 
 # Create build dir if it does not exist
 if [ ! -d "${BUILD_DATA_DIR}" ]; then

--- a/scripts/vagrantCloudBasedContainers.sh
+++ b/scripts/vagrantCloudBasedContainers.sh
@@ -6,7 +6,7 @@
 # It builds a Docker image for GPII/universal and uses it to start two
 # components: the Preferences Server and the Flow Manager.
 #
-# It also starts a CouchDB container and data into
+# It also starts a CouchDB container and loads the CouchDB data into
 # it, so tests running against the GPII components will have access to the
 # latest test data.
 #


### PR DESCRIPTION
This PR moves dataloader from original `gpii-ops/gpii-dataloader` repo into universal.
 
Main reasons behind this:
- Get rid of the duplication of Dockerfile and necessity to maintain extra image and pipeline
- Get rid of cloning the repo and installing npm modules when the container is executed (this would be slow, is prone to errors and would raise question of versioning)
- Data loader will always have the new universal code (as it will be running in the universal image)
- Data loader will get triggered every time there's a change to universal (as the universal image will get updated)

Most of the code was in universal already, and `gpii-ops/gpii-dataloader` contained basically only shell wrapper and the docker image. Work on new dataloader (GPII-3138 and https://github.com/GPII/universal/pull/626) requires changes to the existing dataloader wrapper and therefore presented a good opportunity for the move.

This is a continuation of https://github.com/gpii-ops/gpii-dataloader/pull/6 PR.

Main changes:
- Import deleteAndLoadSnapsets.sh and DataLoader.md
- Add dataLoader dependencies to docker image (jq and curl)
- Update data loader script to reflect new location in universal
- Minor formatting changes
- Add DB connectivity check to dataloader
- Update vagrantCloudBasedContainers.sh to work with new dl location
- Update DataLoader docs to reflect current state

I have tested this locally and plan to create corresponding PR and test for gpii-infra changes required.