### PR TITLE
"Load diff" button no more

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Github thinks our long .js files are generated and hides them from diffs in PRs. Disable that behavior.
+*.js linguist-generated=false


### PR DESCRIPTION
I tested this on my fork, where I no longer need to click "Load diff" on PRs of .js files.

EDIT: link to example PR: https://github.com/mrtyler/universal/pull/1