### PR TITLE
GPII-3394: Add GCP Stackdriver Trace support

### DIFF
--- a/gpii.js
+++ b/gpii.js
@@ -12,6 +12,11 @@ Seventh Framework Programme (FP7/2007-2013) under grant agreement no. 289016.
 You may obtain a copy of the License at
 https://github.com/GPII/universal/blob/master/LICENSE.txt
 */
+if (process.env.GPII_ENABLE_STACKDRIVER_TRACE === "true") {
+    console.log("Enabling @google-cloud/trace-agent")
+    require("@google-cloud/trace-agent").start();
+}
+
 "use strict";
 
 // A simple bootstrap file which allows a configuration of the GPII to be

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "express-session": "1.15.6",
         "fluid-resolve": "1.3.0",
         "glob": "7.1.3",
+        "@google-cloud/trace-agent": "3.2.1",
         "gpii-pouchdb": "1.0.12",
         "infusion": "3.0.0-dev.20181017T162149Z.787f7d5e5",
         "json5": "2.1.0",


### PR DESCRIPTION
Does nothing until https://github.com/gpii-ops/gpii-infra/pull/197 is merged, and for non-GCP [Google Cloud Platform] deployments (e.g. deployments to developer laptops).

I got here by following [these Trace docs](https://cloud.google.com/trace/docs/setup/nodejs).

Tested by hand with a locally-built and locally-run Docker container, and in my GCP dev environment.