### PR TITLE
GPII-3558: Added another registry key to set when switching language

### DIFF
--- a/testData/solutions/win32.json5
+++ b/testData/solutions/win32.json5
@@ -4027,11 +4027,37 @@
                 "supportedSettings": {
                     "PreferredUILanguages": {}
                 }
+            },
+            "configure3": {
+                "type": "gpii.windows.registrySettingsHandler",
+                "liveness": "liveRestart",
+                "options": {
+                    "hKey": "HKEY_CURRENT_USER",
+                    "path": "Control Panel\\International\\User Profile",
+                    "dataTypes": {
+                        "Languages": "REG_MULTI_SZ"
+                    }
+                },
+                "capabilities": [
+                    "http://registry\\.gpii\\.net/common/language"
+                ],
+                "capabilitiesTransformations": {
+                    "Languages": {
+                        "transform": {
+                            "type": "fluid.transforms.value",
+                            "inputPath": "http://registry\\.gpii\\.net/common/language"
+                        }
+                    }
+                },
+                "supportedSettings": {
+                    "Languages": {}
+                }
             }
         },
         "configure": [
             "settings.configure1",
             "settings.configure2",
+            "settings.configure3",
             {
                 "type": "gpii.windows.updateLanguage",
                 "currentLanguage": "${{registry}.HKEY_CURRENT_USER\\Control Panel\\Desktop\\PreferredUILanguages}"
@@ -4040,6 +4066,7 @@
         "restore": [
             "settings.configure1",
             "settings.configure2",
+            "settings.configure3",
             {
                 "type": "gpii.windows.updateLanguage",
                 "currentLanguage": "${{registry}.HKEY_CURRENT_USER\\Control Panel\\Desktop\\PreferredUILanguages}"


### PR DESCRIPTION
Sometimes, the built-in apps names are shown in the wrong language from
the start menu. Setting HKCU\Control Panel\International\User Profile\Languages
and restarting the explorer fixes the issue.