### PR TITLE
GPII-2618: Fixed high-contrast wallpaper not restoring.

### DIFF
--- a/testData/solutions/win32.json5
+++ b/testData/solutions/win32.json5
@@ -4846,7 +4846,7 @@
                     "Pre-High Contrast Scheme": {
                         "transform": {
                             "type": "fluid.transforms.literalValue",
-                            "input": "${{environment}.LOCALAPPDATA}\\Microsoft\\Windows\\Themes\\Morphic.theme"
+                            "input": "${{environment}.USERPROFILE}\\AppData\\Local\\Microsoft\\Windows\\Themes\\Morphic.theme"
                         }
                     }
                 }


### PR DESCRIPTION
Well, another mysterious one.

This fixes the latest high-contrast + wallpaper issue (K2/3/4 in https://docs.google.com/document/d/1Ls7OAZ6l5pi_FHiGJo9Z3NiIL-WPh6Bv4NzJtXGyOpk/edit?ts=5c1c32c9).

I don't know why, but the `LOCALAPPDATA` environment variable had disappeared - this caused the wallpaper to not get saved. I have since reverted and re-updated the VM that had this problem, and the variable has returned. Perhaps it was a faulty update that is now fixed? I found nothing to confirm this.

Instead, the less targeted `USERPROFILE` variable is being used. (I tried `%APPDATA%/../Local`, but it didn't work).

https://issues.gpii.net/browse/GPII-3618 should prevent something like this from happening again.

For reference:
```
APPDATA=C:\Users\vagrant\AppData\Roaming
LOCALAPPDATA=C:\Users\vagrant\AppData\Local
USERPROFILE=C:\Users\vagrant
```
