### PR TITLE
GPII-3741: Add support for "external" CouchDB instance.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "fluid-resolve": "1.3.0",
         "glob": "7.1.3",
         "@google-cloud/trace-agent": "3.4.0",
-        "gpii-couchdb-test-harness": "1.0.0-dev.20190222T084153Z.362b584.GPII-3531",
+        "gpii-couchdb-test-harness": "1.0.0-dev.20190222T143021Z.6e2656a.GPII-3531",
         "infusion": "3.0.0-dev.20181204T213346Z.2ca90f6e6",
         "json5": "2.1.0",
         "kettle": "1.10.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "fluid-resolve": "1.3.0",
         "glob": "7.1.3",
         "@google-cloud/trace-agent": "3.4.0",
-        "gpii-couchdb-test-harness": "1.0.0-dev.20190206T142749Z.d939d49.GPII-3531",
+        "gpii-couchdb-test-harness": "1.0.0-dev.20190222T084153Z.362b584.GPII-3531",
         "infusion": "3.0.0-dev.20181204T213346Z.2ca90f6e6",
         "json5": "2.1.0",
         "kettle": "1.10.1",


### PR DESCRIPTION
This pull updates universal to use the updates to gpii-couchdb-test-harness described in [GPII-3741](https://issues.gpii.net/browse/GPII-3741).