### PR TITLE
GPII-3769: Temporary workaround

### DIFF
--- a/gpii/node_modules/userListeners/src/listeners.js
+++ b/gpii/node_modules/userListeners/src/listeners.js
@@ -166,7 +166,10 @@ gpii.userListeners.tokenRemoved = function (that, token) {
     fluid.log(that.listenerName + " token removed: " + token);
 
     if (!that.proximity) {
-        that.lifecycleManager.performLogout(token);
+        // Temporary workaround for GPII-3769
+        setTimeout(function () {
+            that.lifecycleManager.performLogout(token);
+        }, 0);
     }
 };
 


### PR DESCRIPTION
We are including this workaround for GPII-3769 in the last installer to avoid the problems when keying-out until a proper fix is available.

Don't want this to be merged into master (unless we decide that we want to SHIP IT NOW) but I'm creating this PR just in case.