### PR TITLE
GPII-3811: Made the high-contrast theme work more.

### DIFF
--- a/testData/solutions/win32.json5
+++ b/testData/solutions/win32.json5
@@ -6522,7 +6522,7 @@
             {
                 // Make sure the colours are applied for custom themes.
                 "type": "gpii.windows.spiSettingsHandler.applyCustomTheme",
-                "themeFile": "${{registry}HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\LastHighContrastTheme}"
+                "themeFile": "${{registry}HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\HighContrast\\LastSet}"
             }
         ],
         "restore": [


### PR DESCRIPTION
Fix required for the latest Windows build, 1810 (or whatever is it)