### PR TITLE
 GPII-2338: Stopped GPII crashing on shutdown.

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,6 +89,7 @@ gpii.start = function (options) {
  * Stops the GPII instance that was started with gpii.start()
  */
 gpii.stop = function () {
+    // Destroy the configs in reverse order, so the first loaded one is destroyed last.
     var configs = gpii.queryConfigs().reverse();
     fluid.each(configs, function (config) {
         config.destroy();

--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ gpii.start = function (options) {
  * Stops the GPII instance that was started with gpii.start()
  */
 gpii.stop = function () {
-    var configs = gpii.queryConfigs();
+    var configs = gpii.queryConfigs().reverse();
     fluid.each(configs, function (config) {
         config.destroy();
     });


### PR DESCRIPTION
When cleanly shutting down gpii, a null reference on `shadow` here: https://github.com/fluid-project/infusion/blob/23b4bc89d5bc03087dac78d9d192d3dbbeadeafa/src/framework/core/js/FluidIoC.js#L1068, when dealing with the grade for whatever config was used.

This causes the process to not fully shutdown and linger. This isn't usually noticeable as GPII generally only cleanly shuts down when signing out of Windows (so it just gets killed after some time), but now I'm making the installer shut it down.

Reversing the order in which the configs are disposed prevents this from happening.