### PR TITLE
NOJIRA: Made deleteAndLoadSnapsets.sh posix compliant

### DIFF
--- a/scripts/deleteAndLoadSnapsets.sh
+++ b/scripts/deleteAndLoadSnapsets.sh
@@ -72,7 +72,7 @@ else
 fi
 
 # Initialize (possibly clear) data base
-if [ "${GPII_CLEAR_INDEX}" == 'true' ]; then
+if [ "${GPII_CLEAR_INDEX}" = 'true' ]; then
   log "Deleting database at ${GPII_COUCHDB_URL_SANITIZED}"
   if ! curl -fsS -X DELETE "${GPII_COUCHDB_URL}"; then
     log "Error deleting database"


### PR DESCRIPTION
Some systems have a strict `/bin/sh`, which don't allow non-standard `==` expressions.

(mine links to `dash`)