### PR TITLE
GPII-4250: Remove options modifications after the component construction from flowManager

### DIFF
--- a/gpii/node_modules/flowManager/src/DefaultSettingsLoader.js
+++ b/gpii/node_modules/flowManager/src/DefaultSettingsLoader.js
@@ -43,7 +43,7 @@ fluid.defaults("gpii.defaultSettingsLoader", {
 /**
  * Copy default settings file from the code base to the setting dir if it hasn't been copied.
  *
- * @param {String} defaultSettingsInCodeBase - The path to the QSS settings file.
+ * @param {String} defaultSettingsInCodeBase - The path to the default settings file in the universal code base.
  * @param {String} gpiiSettingsDir - GPII settings directory.
  * @return {Object} Sets that.defaultSettingsFile to the path to the default settings file in the settings dir.
  */

--- a/gpii/node_modules/flowManager/src/FlowManager.js
+++ b/gpii/node_modules/flowManager/src/FlowManager.js
@@ -80,27 +80,14 @@ fluid.defaults("gpii.flowManager.local", {
     // The "suppressHttpEndpoints" flag is to indicate whether to hide un-needed localhost http endpoints.
     // It is turned on in production configs.
     suppressHttpEndpoints: false,
-    contextAwareness: {
-        suppressHttpEndpoints: {
-            checks: {
-                addHttpEndpointsOption: {
-                    contextValue: "{gpii.flowManager.local}.options.suppressHttpEndpoints",
-                    gradeNames: null
-                }
-            },
-            defaultGradeNames: "gpii.flowManager.local.requestHandlers"
+    members: {
+        /* The resolved value is an object containing data for performing reset actions:
+        {
+            defaultSettings: {Object}, // The content of the reset to default file
+            defaultLifecycleInstructions: {Object}, // For the reset action at key-in
+            defaultSnapshot: {Object} // For reset actions at system startup and explicit reset request
         }
-    },
-    distributeOptions: {
-        // Distribute the grade to handle user logon requests.
-        // In all-in-local config, the handler is "gpii.lifecycleManager.userLogonHandling.matchMakingStateChangeHandler".
-        // In untrusted config, the handler should be "gpii.lifecycleManager.untrusted.stateChangeHandler".
-        "lifecycleManager.loginRequestHandler": {
-            record: "gpii.lifecycleManager.userLogonHandling.matchMakingStateChangeHandler",
-            target: "{that gpii.lifecycleManager.loginRequest}.options.gradeNames"
-        },
-        /*
-        Both "defaultSnapshot" and "defaultLifecycleInstructions" structures are generated for performing
+        "defaultSnapshot" and "defaultLifecycleInstructions" structures are generated for performing
         "reset to system default settings" functionality that is applied when:
         1. reset to default settings on system startup using lifecycleManager.restoreSnapshot();
         2. at receiving request "/user/reset/login" to logout the current key and reset to default settings.
@@ -128,15 +115,30 @@ fluid.defaults("gpii.flowManager.local", {
             }
         }
         */
-        // TODO: After FLUID-6148 is implemented, directly saving "defaultLifecycleInstructions" into options should
-        // be replaced by expressing {that}.defaultLifecycleInstructions as an expander in the component's options
-        "userLogonHandling.defaultLifecycleInstructions": {
-            record: "{that}.options.defaultLifecycleInstructions",
-            target: "{that gpii.lifecycleManager.userLogonHandling.stateChangeHandler}.options.defaultLifecycleInstructions"
+        defaultSettingsDataPromise: "@expand:fluid.promise()"
+    },
+    contextAwareness: {
+        suppressHttpEndpoints: {
+            checks: {
+                addHttpEndpointsOption: {
+                    contextValue: "{gpii.flowManager.local}.options.suppressHttpEndpoints",
+                    gradeNames: null
+                }
+            },
+            defaultGradeNames: "gpii.flowManager.local.requestHandlers"
+        }
+    },
+    distributeOptions: {
+        // Distribute the grade to handle user logon requests.
+        // In all-in-local config, the handler is "gpii.lifecycleManager.userLogonHandling.matchMakingStateChangeHandler".
+        // In untrusted config, the handler should be "gpii.lifecycleManager.untrusted.stateChangeHandler".
+        "lifecycleManager.loginRequestHandler": {
+            record: "gpii.lifecycleManager.userLogonHandling.matchMakingStateChangeHandler",
+            target: "{that gpii.lifecycleManager.loginRequest}.options.gradeNames"
         },
-        "userLogonHandling.defaultSnapshot": {
-            record: "{that}.options.defaultSnapshot",
-            target: "{that gpii.lifecycleManager.userLogonHandling.stateChangeHandler}.options.defaultSnapshot"
+        "userLogonHandling.defaultSettingsDataPromise": {
+            record: "{gpii.flowManager.local}.defaultSettingsDataPromise",
+            target: "{that gpii.lifecycleManager.userLogonHandling.stateChangeHandler}.options.defaultSettingsDataPromise"
         },
         "lifecycleManager.privateMatchMaker": {
             record: {
@@ -213,11 +215,12 @@ fluid.defaults("gpii.flowManager.local", {
         preferencesSavedSuccess: null,
         preferencesSavedError: null,
         noUserLoggedIn: null,
-        defaultSnapshotCreated: null,
+        getDefaultSettingsData: null,
+        defaultSettingsDataCreated: null,
         readyToReset: {
             events: {
                 "noUserLoggedIn": "noUserLoggedIn",
-                "defaultSnapshotCreated": "defaultSnapshotCreated"
+                "defaultSettingsDataCreated": "defaultSettingsDataCreated"
             }
         },
         // Fired only when:
@@ -232,18 +235,22 @@ fluid.defaults("gpii.flowManager.local", {
             funcName: "gpii.flowManager.local.mountWebSocketsSettingsHandler",
             args: ["{webSocketsSettingsHandlerComponent}"]
         },
-        "onCreate.loadDefaultSettings": {
-            funcName: "fluid.set",
-            args: ["{that}", ["options", "defaultSettings"], "@expand:{defaultSettingsLoader}.get()"]
+        // Read default settings from the reset to default file, then calculate defaultLifecycleInstructions and
+        // defaultSnapshot based on the default settings.
+        "onCreate.calculateDefaultSettingsData": {
+            listener: "fluid.promise.fireTransformEvent",
+            args: ["{that}.events.getDefaultSettingsData"]
         },
-        // Convert the default settings to lifecycle instruction snapshot only once on system start.
-        "onCreate.convertDefaultSettingsToSnapshot": {
-            funcName: "gpii.flowManager.convertDefaultSettingsToSnapshot",
-            // Passing "{that}.options.defaultSettings" explicitly to ensure it has been resolved by the IoC framework
-            // when reaching the function
-            args: ["{that}", "{that}.options.defaultSettings", "{that}.events.defaultSnapshotCreated"]
-        },
-        // Login with "noUser" when GPII starts so that QSS is still operable
+        getDefaultSettingsData: [{
+            listener: "{defaultSettingsLoader}.get",
+            priority: 100,
+            namespace: "loadDefaultSettngs"
+        }, {
+            listener: "gpii.flowManager.convertDefaultSettingsToSnapshot",
+            args: ["{that}", "{arguments}.0", "{that}.events.defaultSettingsDataCreated"],
+            priority: 90,
+            namespace: "convertDefaultSettings"
+        }],
         "{kettle.server}.events.onListen": {
             listener: "gpii.flowManager.local.noUserLoggedIn",
             args: ["{lifecycleManager}", "{that}.events.noUserLoggedIn"],
@@ -251,7 +258,7 @@ fluid.defaults("gpii.flowManager.local", {
         },
         "readyToReset.resetAtStart": {
             listener: "gpii.flowManager.local.resetAtStart",
-            args: ["{lifecycleManager}", "{that}.options.resetAtStart", "{that}.options.defaultSnapshot", "{that}.events.resetAtStartSuccess", "{that}.events.resetAtStartError"]
+            args: ["{lifecycleManager}", "{that}.options.resetAtStart", "{that}.defaultSettingsDataPromise", "{that}.events.resetAtStartSuccess", "{that}.events.resetAtStartError"]
         },
         "afterDestroy.deregisterInstance": "gpii.singleInstance.deregisterInstance",
         "{lifecycleManager}.events.onAutoSaveRequired": {
@@ -273,38 +280,49 @@ gpii.flowManager.local.noUserLoggedIn = function (lifecycleManager, noUserLogged
     promise.then(noUserLoggedInEvent.fire);
 };
 
-gpii.flowManager.convertDefaultSettingsToSnapshot = function (that, defaultSettings, defaultSnapshotCreatedEvent) {
+gpii.flowManager.convertDefaultSettingsToSnapshot = function (that, defaultSettings, defaultSettingsDataCreatedEvent) {
+    var promiseTogo = fluid.promise();
     if (defaultSettings) {
         var matchMakingPromise = that.privateMatchMaker.doMatch("noUser", defaultSettings);
         matchMakingPromise.then(function (payload) {
             var activePrefsSetName = payload.activePrefsSetName || "gpii-default";
             // convert the matchmaker output to lifecycle instructions
-            that.options.defaultLifecycleInstructions = gpii.transformer.configurationToSettings(payload.matchMakerOutput.inferredConfiguration[activePrefsSetName], payload.solutionsRegistryEntries);
+            var defaultLifecycleInstructions = gpii.transformer.configurationToSettings(payload.matchMakerOutput.inferredConfiguration[activePrefsSetName], payload.solutionsRegistryEntries);
             // convert lifecycle instructions to snapshots
-            that.options.defaultSnapshot = fluid.transform(that.options.defaultLifecycleInstructions, function (handlerResponse) {
+            var defaultSnapshot = fluid.transform(defaultLifecycleInstructions, function (handlerResponse) {
                 return gpii.settingsHandlers.settingsPayloadToChanges(handlerResponse);
             });
-            defaultSnapshotCreatedEvent.fire();
+            promiseTogo.resolve({
+                defaultSettings: defaultSettings,
+                defaultLifecycleInstructions: defaultLifecycleInstructions,
+                defaultSnapshot: defaultSnapshot
+            });
+            defaultSettingsDataCreatedEvent.fire();
         });
     } else {
-        defaultSnapshotCreatedEvent.fire();
+        promiseTogo.resolve({});
+        defaultSettingsDataCreatedEvent.fire();
     }
+    fluid.promise.follow(promiseTogo, that.defaultSettingsDataPromise);
 };
 
-gpii.flowManager.local.resetAtStart = function (lifecycleManager, resetAtStart, defaultSnapshot, resetSuccessEvent, resetErrorEvent) {
-    if (resetAtStart && defaultSnapshot) {
-        fluid.log("Resetting on system startup to default settings: ", defaultSnapshot);
-        var resetPromise = lifecycleManager.restoreSnapshot(defaultSnapshot);
-        resetPromise.then(function () {
-            fluid.log("Resetting on system startup completes successfully.");
+gpii.flowManager.local.resetAtStart = function (lifecycleManager, resetAtStart, defaultSettingsDataPromise, resetSuccessEvent, resetErrorEvent) {
+    defaultSettingsDataPromise.then(function (defaultSettingsData) {
+        var defaultSnapshot = defaultSettingsData.defaultSnapshot;
+        if (resetAtStart && defaultSnapshot) {
+            fluid.log("Resetting on system startup to default settings: ", defaultSnapshot);
+            var resetPromise = lifecycleManager.restoreSnapshot(defaultSnapshot);
+            resetPromise.then(function () {
+                fluid.log("Resetting on system startup completes successfully.");
+                resetSuccessEvent.fire();
+            }, function (error) {
+                fluid.log("Resetting on system startup fails with the error: ", error);
+                resetErrorEvent.fire(error);
+            });
+        } else {
             resetSuccessEvent.fire();
-        }, function (error) {
-            fluid.log("Resetting on system startup fails with the error: ", error);
-            resetErrorEvent.fire(error);
-        });
-    } else {
-        resetSuccessEvent.fire();
-    }
+        }
+    });
 };
 
 /**

--- a/gpii/node_modules/flowManager/src/FlowManager.js
+++ b/gpii/node_modules/flowManager/src/FlowManager.js
@@ -241,16 +241,15 @@ fluid.defaults("gpii.flowManager.local", {
             listener: "fluid.promise.fireTransformEvent",
             args: ["{that}.events.getDefaultSettingsData"]
         },
-        getDefaultSettingsData: [{
+        "getDefaultSettingsData.loadDefaultSettngs": {
             listener: "{defaultSettingsLoader}.get",
-            priority: 100,
-            namespace: "loadDefaultSettngs"
-        }, {
+            priority: 100
+        },
+        "getDefaultSettingsData.convertDefaultSettings": {
             listener: "gpii.flowManager.convertDefaultSettingsToSnapshot",
             args: ["{that}", "{arguments}.0", "{that}.events.defaultSettingsDataCreated"],
-            priority: 90,
-            namespace: "convertDefaultSettings"
-        }],
+            priority: 90
+        },
         "{kettle.server}.events.onListen": {
             listener: "gpii.flowManager.local.noUserLoggedIn",
             args: ["{lifecycleManager}", "{that}.events.noUserLoggedIn"],

--- a/gpii/node_modules/flowManager/src/FlowManager.js
+++ b/gpii/node_modules/flowManager/src/FlowManager.js
@@ -138,7 +138,7 @@ fluid.defaults("gpii.flowManager.local", {
         },
         "userLogonHandling.defaultSettingsDataPromise": {
             record: "{gpii.flowManager.local}.defaultSettingsDataPromise",
-            target: "{that gpii.lifecycleManager.userLogonHandling.stateChangeHandler}.options.defaultSettingsDataPromise"
+            target: "{that gpii.lifecycleManager.userLogonHandling.stateChangeHandler}.options.members.defaultSettingsDataPromise"
         },
         "lifecycleManager.privateMatchMaker": {
             record: {
@@ -243,12 +243,12 @@ fluid.defaults("gpii.flowManager.local", {
         },
         "getDefaultSettingsData.loadDefaultSettngs": {
             listener: "{defaultSettingsLoader}.get",
-            priority: 100
+            priority: "first"
         },
         "getDefaultSettingsData.convertDefaultSettings": {
             listener: "gpii.flowManager.convertDefaultSettingsToSnapshot",
             args: ["{that}", "{arguments}.0", "{that}.events.defaultSettingsDataCreated"],
-            priority: 90
+            priority: "after:loadDefaultSettngs"
         },
         "{kettle.server}.events.onListen": {
             listener: "gpii.flowManager.local.noUserLoggedIn",

--- a/gpii/node_modules/flowManager/src/PSPChannel.js
+++ b/gpii/node_modules/flowManager/src/PSPChannel.js
@@ -16,8 +16,7 @@ fluid.defaults("gpii.pspChannel.sessionBinder", {
             target: "{flowManager}.pspChannel.model",
             singleTransform: {
                 type: "gpii.pspChannel.sessionToPSP",
-                ontologyMetadata: "{ontologyHandler}.ontologyMetadata",
-                defaultSettingControls: "{pspChannel}.defaultSettingControls"
+                ontologyMetadata: "{ontologyHandler}.ontologyMetadata"
             },
             // compensate for FLUID-6194
             backward: "never",
@@ -79,15 +78,7 @@ fluid.defaults("gpii.pspChannel.sessionBinder", {
 fluid.defaults("gpii.pspChannel", {
     gradeNames: ["fluid.modelComponent"],
     members: {
-        outputBlocked: null,
-        // "defaultSettingControls" holds schemas containing default preferences and their values
-        // defined in the reset to default file.
-        defaultSettingControls: {
-            expander: {
-                funcName: "gpii.pspChannel.generateDefaultSettingControls",
-                args: ["{flowManager}.options.defaultSettings", "{ontologyHandler}.ontologyMetadata.flat"]
-            }
-        }
+        outputBlocked: null
     },
     listeners: {
         "{lifecycleManager}.events.onSessionStop": {
@@ -108,45 +99,6 @@ fluid.defaults("gpii.pspChannel", {
         }
     }
 });
-
-/**
- * Calculate the schemas containing preferences with their default values from the reset to default file.
- * @param {Object} defaultSettings - The value of flowManager.options.defaultSettings.
- * @param {Object} schemas - The value of ontologyHandler.ontologyMetadata.flat.
- * @return {Object}  - A collected schema containing schemas for each preference defined in the reset to default file.
- * The default preference values defined in the reset to default file are populated into the "default" field of
- * the returned schema. An example:
- * {
- *     "http://registry\\.gpii\\.net/common/cursorSize": {
- *         "schema": {
- *             "title": "Cursor Size",
- *             "description": "Cursor size",
- *             "type": "number",
- *             "default": 0.8,   // This default value is from the reset to default file
- *             "minimum": 0,
- *             "maximum": 1,
- *             "multipleOf": 0.1
- *         },
- *         "liveness": "live"
- *     },
- *     ...
- * }
- */
-gpii.pspChannel.generateDefaultSettingControls = function (defaultSettings, schemas) {
-    var defaultSettingControls = {};
-    var defaultPreferences = fluid.get(defaultSettings, ["contexts", "gpii-default", "preferences"]);
-
-    // Set the setting default values from reset to standard file to schema.default field for each setting in
-    // "settingControls" block.
-    fluid.each(defaultPreferences, function (defaultPrefsVal, defaultPrefsKey) {
-        if (schemas[defaultPrefsKey]) {
-            var schemaWithDefault = fluid.copy(schemas[defaultPrefsKey]);
-            fluid.set(schemaWithDefault, ["schema", "default"], defaultPrefsVal);
-            gpii.pspChannel.emitSettingControl(defaultSettingControls, schemaWithDefault, undefined, [defaultPrefsKey], "live");
-        }
-    });
-    return defaultSettingControls;
-};
 
 gpii.pspChannel.updatePrefsSetName = function (lifecycleManager, pspChannel, newPrefsSetName) {
     fluid.log("Received prefsSet update from PSP UI of ", newPrefsSetName);
@@ -253,8 +205,7 @@ gpii.pspChannel.sessionToPSP = function (model, transformSpec) {
             gpii.pspChannel.emitSettingControl(settingControls, schemas[prefsKey], prefsVal, [prefsKey], liveness);
         }
     });
-    // GPII-3828: Return default values defined in the reset to default file rather than ones from the ontologyMetadata
-    outModel.settingControls = fluid.extend(true, {}, settingControls, transformSpec.defaultSettingControls || {});
+    outModel.settingControls = settingControls;
     outModel.preferences = {
         name: fluid.get(model, "preferences.name"),
         contexts: fluid.transform(fluid.get(model, "preferences.contexts"), function (contextVal) {

--- a/gpii/node_modules/lifecycleManager/src/UserLogonStateChange.js
+++ b/gpii/node_modules/lifecycleManager/src/UserLogonStateChange.js
@@ -25,7 +25,7 @@ fluid.registerNamespace("gpii.lifecycleManager.userLogonHandling");
 gpii.lifecycleManager.userLogonHandling.handleResetGpiiKey = function (that, lifecycleManager) {
     var activeGpiiKey = lifecycleManager.getActiveSessionGpiiKey(); // find currently logged in user:
 
-    that.options.defaultSettingsDataPromise.then(function (defaultSettingsData) {
+    that.defaultSettingsDataPromise.then(function (defaultSettingsData) {
         var resetActions = [];
         if (activeGpiiKey) {
             fluid.log("Reset: logging out the user with GPII key " + activeGpiiKey);
@@ -50,7 +50,7 @@ gpii.lifecycleManager.userLogonHandling.handleResetGpiiKey = function (that, lif
 
 gpii.lifecycleManager.userLogonHandling.startLifecycle = function (that, lifecycleManager, lifecyclePayload, event) {
     gpii.logFully("userLogonHandling.startLifecycle got final payload ", gpii.renderMegapayload(lifecyclePayload));
-    that.options.defaultSettingsDataPromise.then(function (defaultSettingsData) {
+    that.defaultSettingsDataPromise.then(function (defaultSettingsData) {
         if (defaultSettingsData.defaultLifecycleInstructions && lifecyclePayload.gpiiKey !== "noUser") {
             // Merge the default snapshot with current key's lifecycle instructions to combine the key in action
             // with "reset all" functionality
@@ -173,7 +173,9 @@ gpii.lifecycleManager.getDeviceContext = function (deviceReporter, event, errorE
 
 // A mixin grade for a matchMakingRequest request handler, supporting local user logon
 fluid.defaults("gpii.lifecycleManager.userLogonHandling.stateChangeHandler", {
-    defaultSettingsDataPromise: null, // A promise distributed from "gpii.flowManager.local". containing data for reset actions.
+    members: {
+        defaultSettingsDataPromise: null // A promise distributed from "gpii.flowManager.local". containing data for reset actions.
+    },
     invokers: {
         getDeviceContext: {
             funcName: "gpii.lifecycleManager.getDeviceContext",

--- a/gpii/node_modules/lifecycleManager/src/UserLogonStateChange.js
+++ b/gpii/node_modules/lifecycleManager/src/UserLogonStateChange.js
@@ -24,45 +24,48 @@ fluid.registerNamespace("gpii.lifecycleManager.userLogonHandling");
 
 gpii.lifecycleManager.userLogonHandling.handleResetGpiiKey = function (that, lifecycleManager) {
     var activeGpiiKey = lifecycleManager.getActiveSessionGpiiKey(); // find currently logged in user:
-    var defaultSnapshot = that.options.defaultSnapshot;
 
-    var resetActions = [];
-    if (activeGpiiKey) {
-        fluid.log("Reset: logging out the user with GPII key " + activeGpiiKey);
-        resetActions.push(that.logoutUserWithoutResponse(activeGpiiKey));
-    }
-    if (defaultSnapshot) {
-        fluid.log("Reset: restoring the system to the default snapshot: ", defaultSnapshot);
-        resetActions.push(lifecycleManager.restoreSnapshot(defaultSnapshot));
-    }
-    var promise = fluid.promise.sequence(resetActions);
+    that.options.defaultSettingsDataPromise.then(function (defaultSettingsData) {
+        var resetActions = [];
+        if (activeGpiiKey) {
+            fluid.log("Reset: logging out the user with GPII key " + activeGpiiKey);
+            resetActions.push(that.logoutUserWithoutResponse(activeGpiiKey));
+        }
+        if (defaultSettingsData.defaultSnapshot) {
+            fluid.log("Reset: restoring the system to the default snapshot: ", defaultSettingsData.defaultSnapshot);
+            resetActions.push(lifecycleManager.restoreSnapshot(defaultSettingsData.defaultSnapshot));
+        }
+        var promise = fluid.promise.sequence(resetActions);
 
-    // A separate logout of "reset" is not necessary because of the special behavior of restoreSnapshot() that uses a
-    // special "restore" key and also detroys the restore session once the restoration completes. The final condition
-    // of using the "reset" key is to have the "noUser" log back in the system.
-    promise.then(function () {
-        that.events.onSuccess.fire("Reset successfully.");
-    }, function (error) {
-        lifecycleManager.errorResponse(that, "Reset: Error occurred during logout: " + error.message);
+        // A separate logout of "reset" is not necessary because of the special behavior of restoreSnapshot() that uses a
+        // special "restore" key and also detroys the restore session once the restoration completes. The final condition
+        // of using the "reset" key is to have the "noUser" log back in the system.
+        promise.then(function () {
+            that.events.onSuccess.fire("Reset successfully.");
+        }, function (error) {
+            lifecycleManager.errorResponse(that, "Reset: Error occurred during logout: " + error.message);
+        });
     });
 };
 
 gpii.lifecycleManager.userLogonHandling.startLifecycle = function (that, lifecycleManager, lifecyclePayload, event) {
     gpii.logFully("userLogonHandling.startLifecycle got final payload ", gpii.renderMegapayload(lifecyclePayload));
-    if (that.options.defaultLifecycleInstructions && lifecyclePayload.gpiiKey !== "noUser") {
-        // Merge the default snapshot with current key's lifecycle instructions to combine the key in action
-        // with "reset all" functionality
-        fluid.set(lifecyclePayload, ["activeConfiguration", "lifecycleInstructions"], fluid.extend(
-            true, {}, that.options.defaultLifecycleInstructions, fluid.get(lifecyclePayload, ["activeConfiguration", "lifecycleInstructions"])
-        ));
-    }
-    var promise = lifecycleManager.start(lifecyclePayload);
-    promise.then(function () {
-        gpii.lifecycleManager.userLogonHandling.updateLogonChangeModel(lifecycleManager, lifecyclePayload.gpiiKey, "login", false);
-        event.fire("User with GPII key " + lifecyclePayload.gpiiKey + " was successfully logged in.");
-    }, function (error) {
-        fluid.log(fluid.logLevel.FAIL, "Error returned from lifecycle manager: ", error);
-        lifecycleManager.errorResponse(that, "Error occurred during login: " + error.message);
+    that.options.defaultSettingsDataPromise.then(function (defaultSettingsData) {
+        if (defaultSettingsData.defaultLifecycleInstructions && lifecyclePayload.gpiiKey !== "noUser") {
+            // Merge the default snapshot with current key's lifecycle instructions to combine the key in action
+            // with "reset all" functionality
+            fluid.set(lifecyclePayload, ["activeConfiguration", "lifecycleInstructions"], fluid.extend(
+                true, {}, defaultSettingsData.defaultLifecycleInstructions, fluid.get(lifecyclePayload, ["activeConfiguration", "lifecycleInstructions"])
+            ));
+        }
+        var promise = lifecycleManager.start(lifecyclePayload);
+        promise.then(function () {
+            gpii.lifecycleManager.userLogonHandling.updateLogonChangeModel(lifecycleManager, lifecyclePayload.gpiiKey, "login", false);
+            event.fire("User with GPII key " + lifecyclePayload.gpiiKey + " was successfully logged in.");
+        }, function (error) {
+            fluid.log(fluid.logLevel.FAIL, "Error returned from lifecycle manager: ", error);
+            lifecycleManager.errorResponse(that, "Error occurred during login: " + error.message);
+        });
     });
 };
 
@@ -170,8 +173,9 @@ gpii.lifecycleManager.getDeviceContext = function (deviceReporter, event, errorE
 
 // A mixin grade for a matchMakingRequest request handler, supporting local user logon
 fluid.defaults("gpii.lifecycleManager.userLogonHandling.stateChangeHandler", {
+    defaultSettingsDataPromise: null, // A promise distributed from "gpii.flowManager.local". containing data for reset actions.
     invokers: {
-        getDeviceContext: { // TODO: remember to close GPII-1770 now this is correctly factored
+        getDeviceContext: {
             funcName: "gpii.lifecycleManager.getDeviceContext",
             args: ["{flowManager}.deviceReporter", "{that}.events.onDeviceContext", "{that}.events.onError"]
         },

--- a/testData/solutions/linux.json5
+++ b/testData/solutions/linux.json5
@@ -20,12 +20,76 @@
                     "schema": "org.gnome.desktop.a11y.magnifier"
                 },
                 "supportedSettings": {
-                    "mag-factor": {},
-                    "show-cross-hairs": {},
-                    "focus-tracking": {},
-                    "caret-tracking": {},
-                    "mouse-tracking": {},
-                    "screen-position": {}
+                    "mag-factor": {
+                        "schema": {
+                            "title": "Magnification",
+                            "description": "Set up magnification level",
+                            "type": "number",
+                            "default": 1,
+                            "minimum": 1,
+                            "maximum": 5
+                        }
+                    },
+                    "show-cross-hairs": {
+                        "schema": {
+                            "title": "Show Cross Hairs",
+                            "description": "Cross hairs follows the mouse cursor",
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    "focus-tracking": {
+                        "schema": {
+                            "title": "Focus Tracking",
+                            "description": "The mouse pointer is always in view within the magnifier",
+                            "default": 0,
+                            "enum": [0, 1, 2, 3],
+                            "enumLabels": ["None", "Centered", "Push", "Proportional"]
+                        }
+                    },
+                    "caret-tracking": {
+                        "schema": {
+                            "title": "Caret Tracking",
+                            "description": "The mouse pointer is always in view within the magnifier",
+                            "default": 0,
+                            "enum": [0, 1, 2, 3],
+                            "enumLabels": ["None", "Centered", "Push", "Proportional"]
+                        }
+                    },
+                    "lens-mode": {
+                        "schema": {
+                            "title": "Enable lens mode",
+                            "description": "Whether the magnified view should be centered over the location of the system mouse and move with it",
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    "mouse-tracking": {
+                        "schema": {
+                            "title": "Mouse Tracking Mode",
+                            "description": "Determines the position of the magnified mouse image within the magnified view and how it reacts to system mouse movement",
+                            "default": "proportional",
+                            "enum": ["none", "centered", "push", "proportional"],
+                            "enumLabels": ["None", "Centered", "Push", "Proportional"]
+                        }
+                    },
+                    "screen-position": {
+                        "schema": {
+                            "title": "Screen Position",
+                            "description": "The position of the magnified view",
+                            "default": "full-screen",
+                            "enum": ["full-screen", "top-half", "bottom-half", "left-half", "right-half"],
+                            "enumLabels": ["Full screen", "Top half", "Bottom half", "Left half", "Right half"]
+                        }
+                    },
+                    "scroll-at-edges": {
+                        "schema": {
+                            "title": "Scroll magnified contents beyond the edges of the desktop",
+                            "description": "For centered mouse tracking, when the system pointer is at or near the edge of the screen, the magnified contents continue to scroll such that the screen edge moves into the magnified view",
+                            "type": "boolean",
+                            "default": false
+                        }
+                    }
                 },
                 "capabilitiesTransformations": {
                     "mag-factor": "http://registry\\.gpii\\.net/common/magnification",
@@ -122,10 +186,40 @@
                 "type": "gpii.gsettings",
                 "liveness": "live",
                 "supportedSettings": {
-                    "text-scaling-factor": {},
-                    "cursor-size": {},
-                    "gtk-theme": {},
-                    "icon-theme": {}
+                    "text-scaling-factor": {
+                        "schema": {
+                            "title": "Text scaling factor",
+                            "description": "Factor used to enlarge or reduce text display, without changing font size",
+                            "type": "number",
+                            "default": 1,
+                            "minimum": 0.5,
+                            "maximum": 3
+                        }
+                    },
+                    "cursor-size": {
+                        "schema": {
+                            "title": "Cursor size",
+                            "description": "Size of the cursor used as cursor theme",
+                            "type": "number",
+                            "default": 24
+                        }
+                    },
+                    "gtk-theme": {
+                        "schema": {
+                            "title": "Gtk+ Theme",
+                            "description": "Basename of the default theme used by gtk+",
+                            "type": "string",
+                            "default": "Adwaita"
+                        }
+                    },
+                    "icon-theme": {
+                        "schema": {
+                            "title": "Icon Theme",
+                            "description": "Icon theme to use for the panel, nautilus etc",
+                            "type": "string",
+                            "default": "Adwaita"
+                        }
+                    }
                 },
                 "capabilitiesTransformations": {
                     "text-scaling-factor": {
@@ -439,17 +533,103 @@
                     "user": "${{gpiiKey}}"
                 },
                 "supportedSettings": {
-                    "enableTutorialMessages": {},
-                    "enableEchoByCharacter": {},
-                    "enableEchoByWord": {},
-                    "enableBraille": {},
-                    "enableSpeech": {},
-                    "sayAllStyle": {},
-                    "voices.default.rate": {},
-                    "voices.default.average-pitch": {},
-                    "voices.default.gain": {},
-                    "voices.default.family": {},
-                    "verbalizePunctuationStyle": {}
+                    "enableTutorialMessages": {
+                        "schema": {
+                            "title": "Enable Tutorial Messages",
+                            "description": "Enable tutorial messages",
+                            "enum": [0, 1],
+                            "enumLabels": ["off", "on"],
+                            "default": 0
+                        }
+                    },
+                    "enableEchoByCharacter": {
+                        "schema": {
+                            "title": "Enable Echo by Character",
+                            "description": "Enable echo by character",
+                            "enum": [0, 1],
+                            "enumLabels": ["off", "on"],
+                            "default": 0
+                        }
+                    },
+                    "enableEchoByWord": {
+                        "schema": {
+                            "title": "Enable Echo by Word",
+                            "description": "Enable echo by word",
+                            "enum": [0, 1],
+                            "enumLabels": ["off", "on"],
+                            "default": 0
+                        }
+                    },
+                    "enableBraille": {
+                        "schema": {
+                            "title": "Enable Braille",
+                            "description": "Enable braille",
+                            "enum": [0, 1],
+                            "enumLabels": ["off", "on"],
+                            "default": 0
+                        }
+                    },
+                    "enableSpeech": {
+                        "schema": {
+                            "title": "Enable Speech",
+                            "description": "Enable speech",
+                            "enum": [0, 1],
+                            "enumLabels": ["off", "on"],
+                            "default": 0
+                        }
+                    },
+                    "sayAllStyle": {
+                        "schema": {
+                            "title": "Enable Say all Style",
+                            "description": "Enable say all style",
+                            "enum": [0, 1],
+                            "enumLabels": ["off", "on"],
+                            "default": 0
+                        }
+                    },
+                    "voices.default.rate": {
+                        "schema": {
+                            "title": "Voice Rate",
+                            "description": "Config the voice rate",
+                            "type": "number",
+                            "default": 100
+                        }
+                    },
+                    "voices.default.average-pitch": {
+                        "schema": {
+                            "title": "Voice Average Pitch",
+                            "description": "Config the voice average pitch",
+                            "type": "number",
+                            "default": 10
+                        }
+                    },
+                    "voices.default.gain": {
+                        "schema": {
+                            "title": "Voice Gain",
+                            "description": "Config the voice gain",
+                            "type": "number",
+                            "default": 10
+                        }
+                    },
+                    "voices.default.family": {
+                        "schema": {
+                            "title": "Voice Family",
+                            "description": "Config the voice family to be used",
+                            "default": {
+                                "locale": "en",
+                                "name": "english"
+                            }
+                        }
+                    },
+                    "verbalizePunctuationStyle": {
+                        "schema": {
+                            "title": "Verbalize Punctuation Style",
+                            "description": "Config the verbalize punctuation style",
+                            "enum": [0, 1, 2, 3],
+                            "enumLabels": ["none", "some", "most", "all"],
+                            "default": 0
+                        }
+                    }
                 },
                 "capabilitiesTransformations": {
                     "enableTutorialMessages": "http://registry\\.gpii\\.net/common/speakTutorialMessages",

--- a/tests/PSPIntegrationTests.js
+++ b/tests/PSPIntegrationTests.js
@@ -30,12 +30,6 @@ gpii.tests.pspIntegration.buildTestDefs = function (testDefs) {
             config: {
                 configName: "gpii.tests.acceptance.pspIntegration.config",
                 configPath: "%gpii-universal/tests/configs"
-            },
-            distributeOptions: {
-                "acceptance.defaultSettings": {
-                    record: "{that}.options.defaultSettings",
-                    target: "{that gpii.flowManager.local}.options.defaultSettings"
-                }
             }
         }, testDef);
     });

--- a/tests/UntrustedPSPIntegrationTests.js
+++ b/tests/UntrustedPSPIntegrationTests.js
@@ -70,12 +70,6 @@ fluid.defaults("gpii.tests.untrusted.pspIntegration.testCaseHolder", {
     gradeNames: [
         "gpii.tests.pspIntegration.testCaseHolder.common.linux"
     ],
-    distributeOptions: {
-        "acceptance.defaultSettings": {
-            record: "{that}.options.defaultSettings",
-            target: "{that gpii.flowManager.local}.options.defaultSettings"
-        }
-    },
     components: {
         rawPrefsAtStart: {
             type: "gpii.test.untrusted.pspIntegration.rawPrefsRequest"
@@ -115,7 +109,7 @@ gpii.test.untrusted.pspIntegration.expectedPrefsChange = [
                     "name": "Default preferences",
                     "preferences": {
                         "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier": {
-                            "http://registry.gpii.net/common/magnification": 3
+                            "mag-factor": 3
                         }
                     }
                 }
@@ -146,7 +140,7 @@ gpii.test.untrusted.pspIntegration.expectedPrefsChange = [
                         "http://registry.gpii.net/common/magnification": 1.5,
                         "http://registry.gpii.net/common/volume": 0.5,
                         "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier": {
-                            "http://registry.gpii.net/common/magnification": 3
+                            "mag-factor": 3
                         }
                     }
                 }

--- a/tests/configs/gpii.tests.acceptance.pspIntegration.config.json5
+++ b/tests/configs/gpii.tests.acceptance.pspIntegration.config.json5
@@ -1,13 +1,5 @@
 {
     "type": "gpii.tests.acceptance.pspIntegration.config",
-    "options": {
-        "distributeOptions": {
-            "acceptance.flowManagerOptions": {
-                "source": "{that}.options.flowManagerOptions",
-                "target": "{that gpii.flowManager.local}.options"
-            }
-        }
-    },
     "mergeConfigs": [
         "%gpii-universal/tests/platform/linux/configs/gpii.tests.acceptance.linux.builtIn.config",
         "./shared/gpii.tests.resetDefaultSettings.config.json5"

--- a/tests/configs/gpii.tests.acceptance.resetAtStart.config.json5
+++ b/tests/configs/gpii.tests.acceptance.resetAtStart.config.json5
@@ -2,10 +2,6 @@
     "type": "gpii.tests.acceptance.resetAtStart.config",
     "options": {
         "distributeOptions": {
-            "acceptance.defaultSettings": {
-                "source": "{that}.options.flowManagerOptions",
-                "target": "{that gpii.flowManager.local}.options"
-            },
             "acceptance.resetAtStart": {
                 "record": true,
                 "target": "{that gpii.flowManager.local}.options.resetAtStart"

--- a/tests/configs/gpii.tests.acceptance.untrusted.pspIntegration.config.json
+++ b/tests/configs/gpii.tests.acceptance.untrusted.pspIntegration.config.json
@@ -5,10 +5,6 @@
             "acceptance.cloudBasedConfig.preferencesServer": {
                 "record": "gpii.tests.untrusted.pspIntegration.preferencesServer",
                 "target": "{that cloudBasedConfig preferencesServer}.type"
-            },
-            "acceptance.flowManagerOptions": {
-                "source": "{that}.options.flowManagerOptions",
-                "target": "{that gpii.flowManager.local}.options"
             }
         }
     },

--- a/tests/configs/shared/gpii.tests.resetDefaultSettings.config.json5
+++ b/tests/configs/shared/gpii.tests.resetDefaultSettings.config.json5
@@ -6,11 +6,21 @@
             // that this test is running on.
             "components": {
                 "defaultSettingsLoader": {
-                    "type": "fluid.emptySubcomponent"
+                    "type": "fluid.component",
+                    "options": {
+                        "invokers": {
+                            "get": {
+                                "funcName": "fluid.identity"
+                            }
+                        }
+                    }
                 }
-            },
-            "listeners": {
-                "onCreate.loadDefaultSettings": "fluid.identity"
+            }
+        },
+        "distributeOptions": {
+            "acceptance.flowManagerOptions": {
+                "source": "{that}.options.flowManagerOptions",
+                "target": "{that gpii.flowManager.local}.options"
             }
         }
     }

--- a/tests/configs/shared/gpii.tests.userLogon.config.json5
+++ b/tests/configs/shared/gpii.tests.userLogon.config.json5
@@ -16,19 +16,23 @@
             // that this test is running on.
             "components": {
                 "defaultSettingsLoader": {
-                    "type": "fluid.emptySubcomponent"
-                }
-            },
-            "listeners": {
-                "onCreate.loadDefaultSettings": "fluid.identity"
-            },
-            "defaultSettings": {
-                "contexts": {
-                    "gpii-default": {
-                        "preferences": {
-                            "http://registry.gpii.net/common/magnification/enabled": false,
-                            "http://registry.gpii.net/common/cursorSize": 0.5,
-                            "http://registry.gpii.net/common/volume": 0.75
+                    "type": "fluid.component",
+                    "options": {
+                        "invokers": {
+                            "get": {
+                                "funcName": "fluid.identity",
+                                "args": [{
+                                    "contexts": {
+                                        "gpii-default": {
+                                            "preferences": {
+                                                "http://registry.gpii.net/common/magnification/enabled": false,
+                                                "http://registry.gpii.net/common/cursorSize": 0.5,
+                                                "http://registry.gpii.net/common/volume": 0.75
+                                            }
+                                        }
+                                    }
+                                }]
+                            }
                         }
                     }
                 }

--- a/tests/data/preferences/context1.json5
+++ b/tests/data/preferences/context1.json5
@@ -16,7 +16,7 @@
                             "http://registry.gpii.net/common/volume",
                             [
                                 "http://registry.gpii.net/applications/org.gnome.desktop.a11y.magnifier",
-                                "http://registry.gpii.net/common/magnification"
+                                "mag-factor"
                             ]
                         ]
                     }

--- a/tests/shared/PSPIntegrationTestDefs.js
+++ b/tests/shared/PSPIntegrationTestDefs.js
@@ -172,7 +172,7 @@ gpii.tests.pspIntegration.data = {
                 "data": [{
                     "settings": {
                         "mag-factor": 3,
-                        "show-cross-hairs": 1
+                        "show-cross-hairs": true
                     },
                     "options": {
                         "schema": "org.gnome.desktop.a11y.magnifier"
@@ -442,7 +442,7 @@ gpii.tests.pspIntegration.testDefs = [
                 args: ["{arguments}.0", "modelChanged", "{that}.options.expectedSettingControls.afterConnect"]
             }, {
                 funcName: "gpii.tests.pspIntegration.sendMsg",
-                args: [ "{pspClient}", [ "preferences","http://registry\\.gpii\\.net/applications/org\\.gnome\\.desktop\\.a11y\\.magnifier.http://registry\\.gpii\\.net/common/magnification"], 3]
+                args: [ "{pspClient}", [ "preferences","http://registry\\.gpii\\.net/applications/org\\.gnome\\.desktop\\.a11y\\.magnifier.mag-factor"], 3]
             }, {
                 event: "{pspClient}.events.onReceiveMessage",
                 listener: "gpii.tests.pspIntegration.checkPayload",
@@ -577,7 +577,7 @@ gpii.tests.pspIntegration.testDefs = [
                 args: ["{arguments}.0", "modelChanged"]
             }, {
                 funcName: "gpii.tests.pspIntegration.sendMsg",
-                args: ["{pspClient}", [ "preferences","http://registry\\.gpii\\.net/applications/org\\.gnome\\.desktop\\.a11y\\.magnifier.http://registry\\.gpii\\.net/common/magnification"], 3]
+                args: ["{pspClient}", [ "preferences","http://registry\\.gpii\\.net/applications/org\\.gnome\\.desktop\\.a11y\\.magnifier.mag-factor"], 3]
             }, {
                 event: "{pspClient}.events.onReceiveMessage",
                 listener: "gpii.tests.pspIntegration.checkPayload",
@@ -594,7 +594,7 @@ gpii.tests.pspIntegration.testDefs = [
                 listener: "fluid.identity"
             }, {
                 funcName: "gpii.tests.pspIntegration.sendMsg",
-                args: ["{pspClient}", [ "preferences","http://registry\\.gpii\\.net/applications/org\\.gnome\\.desktop\\.a11y\\.magnifier.http://registry\\.gpii\\.net/common/showCrosshairs"], 1]
+                args: ["{pspClient}", [ "preferences","http://registry\\.gpii\\.net/applications/org\\.gnome\\.desktop\\.a11y\\.magnifier.show-cross-hairs"], true]
             }, {
                 event: "{pspClient}.events.onReceiveMessage",
                 listener: "gpii.tests.pspIntegration.checkPayload",
@@ -791,7 +791,7 @@ gpii.tests.pspIntegration.testDefs = [
             }, {
                 // Issue a setting change that will be applied using the async mock settings handler
                 funcName: "gpii.tests.pspIntegration.sendMsg",
-                args: [ "{pspClient}", [ "preferences","http://registry\\.gpii\\.net/applications/org\\.gnome\\.orca.http://registry\\.gpii\\.net/common/screenReaderTTS/enabled"], true]
+                args: [ "{pspClient}", [ "preferences","http://registry\\.gpii\\.net/applications/org\\.gnome\\.orca.enableSpeech"], true]
             }, {
                 event: "{pspClient}.events.onReceiveMessage",
                 listener: "gpii.tests.pspIntegration.checkPayload",
@@ -849,157 +849,6 @@ gpii.tests.pspIntegration.testDefs = [
                 args: ["{arguments}.0", "modelChanged", "{that}.options.expectedSettingControls.noUser"]
             },
             {
-                funcName: "gpii.tests.pspIntegration.sendMsg",
-                args: [ "{pspClient}", ["preferences", "http://registry\\.gpii\\.net/common/cursorSize"], 0.9]
-            },
-            {
-                event: "{pspClient}.events.onReceiveMessage",
-                listener: "gpii.tests.pspIntegration.checkPayload",
-                args: ["{arguments}.0", "modelChanged", "{that}.options.expectedSettingControls.afterChangeCursorSize"]
-            }
-        ]
-    }, {
-        name: "GPII-3828: PSPChannel reports default settings from the reset to default file when settingControls block is empty",
-        expect: 10,
-        "defaultSettings": {
-            "contexts": {
-                "gpii-default": {
-                    "preferences": {
-                        "http://registry.gpii.net/common/cursorSize": 0.8,
-                        "http://registry.gpii.net/common/volume": 1
-                    }
-                }
-            }
-        },
-        expectedSettingControls: {
-            noUser: {
-                "http://registry\\.gpii\\.net/common/cursorSize": {
-                    "schema": {
-                        "title": "Cursor Size",
-                        "description": "Cursor size",
-                        "type": "number",
-                        "default": 0.8,
-                        "minimum": 0,
-                        "maximum": 1,
-                        "multipleOf": 0.1
-                    },
-                    "liveness": "live"
-                },
-                "http://registry\\.gpii\\.net/common/volume": {
-                    "schema": {
-                        "title": "Volume",
-                        "description": "General volume of the operating system",
-                        "type": "number",
-                        "minimum": 0,
-                        "maximum": 1,
-                        "default": 1
-                    },
-                    "liveness": "live"
-                }
-            },
-            afterChangeMagnification: {
-                "http://registry\\.gpii\\.net/common/cursorSize": {
-                    "schema": {
-                        "title": "Cursor Size",
-                        "description": "Cursor size",
-                        "type": "number",
-                        "default": 0.8,
-                        "minimum": 0,
-                        "maximum": 1,
-                        "multipleOf": 0.1
-                    },
-                    "liveness": "live"
-                },
-                "http://registry\\.gpii\\.net/common/volume": {
-                    "schema": {
-                        "title": "Volume",
-                        "description": "General volume of the operating system",
-                        "type": "number",
-                        "minimum": 0,
-                        "maximum": 1,
-                        "default": 1
-                    },
-                    "liveness": "live"
-                },
-                "http://registry\\.gpii\\.net/common/magnification": {
-                    "value": 3,
-                    "schema": {
-                        "title": "Magnification",
-                        "description": "Level of magnification",
-                        "type": "number",
-                        "default": 1,
-                        "minimum": 1,
-                        "multipleOf": 0.1
-                    },
-                    "liveness": "live"
-                }
-            },
-            afterChangeCursorSize: {
-                "http://registry\\.gpii\\.net/common/cursorSize": {
-                    "value": 0.9,
-                    "schema": {
-                        "title": "Cursor Size",
-                        "description": "Cursor size",
-                        "type": "number",
-                        "default": 0.8,
-                        "minimum": 0,
-                        "maximum": 1,
-                        "multipleOf": 0.1
-                    },
-                    "liveness": "live"
-                },
-                "http://registry\\.gpii\\.net/common/volume": {
-                    "schema": {
-                        "title": "Volume",
-                        "description": "General volume of the operating system",
-                        "type": "number",
-                        "minimum": 0,
-                        "maximum": 1,
-                        "default": 1
-                    },
-                    "liveness": "live"
-                }
-            }
-        },
-        sequence: [
-            {
-                func: "{pspClient}.connect"
-            },
-            {
-                event: "{pspClient}.events.onConnect",
-                listener: "gpii.tests.pspIntegration.connectionSucceeded"
-            },
-            {
-                event: "{pspClient}.events.onReceiveMessage",
-                listener: "gpii.tests.pspIntegration.checkPayload",
-                args: ["{arguments}.0", "modelChanged", "{that}.options.expectedSettingControls.noUser"]
-            },
-            {
-                funcName: "gpii.tests.pspIntegration.sendMsg",
-                args: [ "{pspClient}", ["preferences", "http://registry\\.gpii\\.net/common/magnification"], 3]
-            },
-            {
-                event: "{pspClient}.events.onReceiveMessage",
-                listener: "gpii.tests.pspIntegration.checkPayload",
-                args: ["{arguments}.0", "modelChanged", "{that}.options.expectedSettingControls.afterChangeMagnification"]
-            },
-            {
-                func: "{resetRequest}.send"
-            },
-            {
-                event: "{resetRequest}.events.onComplete",
-                listener: "gpii.tests.pspIntegration.checkResetResponse",
-                args: ["{arguments}.0"]
-            },
-            {
-                // When "noUser" keys back in, PSP client receives empty settingControls block.
-                event: "{pspClient}.events.onReceiveMessage",
-                listener: "gpii.tests.pspIntegration.checkPayload",
-                args: ["{arguments}.0", "modelChanged", "{that}.options.expectedSettingControls.noUser"]
-            },
-            {
-                // change a setting that is in default settings from the reset to standard file.
-                // settingControls.settingKey.schema.default should be set to the value from the default setting.
                 funcName: "gpii.tests.pspIntegration.sendMsg",
                 args: [ "{pspClient}", ["preferences", "http://registry\\.gpii\\.net/common/cursorSize"], 0.9]
             },

--- a/tests/shared/ResetDefaultSettingsTestDefs.js
+++ b/tests/shared/ResetDefaultSettingsTestDefs.js
@@ -96,8 +96,10 @@ gpii.tests.resetDefaultSettings.buildTestDefs = function (testCases, config) {
             config: config,
             "distributeOptions": {
                 "acceptance.defaultSettings": {
-                    "record": oneTestCase.defaultSettings,
-                    "target": "{that gpii.flowManager.local}.options.defaultSettings"
+                    "record": {
+                        args: oneTestCase.defaultSettings
+                    },
+                    "target": "{that defaultSettingsLoader}.options.invokers.get"
                 }
             }
         }, testCaseOptions, testSequence);


### PR DESCRIPTION
This pull request also removes the inoperative implementation for [GPII-3828](https://issues.gpii.net/browse/GPII-3828) from the code. There has been [a new pull request for GPII-3828](https://github.com/GPII/universal/pull/820), which will be adjusted when this pull request is merged.