### PR TITLE
GPII-4225: Fix the issue with keying in "jaws"

### DIFF
--- a/gpii/node_modules/ontologyHandler/src/ontologyHandler.js
+++ b/gpii/node_modules/ontologyHandler/src/ontologyHandler.js
@@ -485,7 +485,7 @@ URLs - this aspect is taken care of in the preferences server component.
             if (transformSpec === undefined) {
                 return {};
             }
-            var prefsSetTransform = gpii.ontologyHandler.makePreferencesPrefsSetTransform(transformSpec);
+            var prefsSetTransform = gpii.ontologyHandler.makePrefsSetTransform(transformSpec);
             transformed.contexts = fluid.transform(transformed.contexts, prefsSetTransform);
             // translate the preferences set's independent metadata block:
             transformed.metadata = gpii.ontologyHandler.transformMetadata(transformed.metadata, transformSpec);
@@ -502,7 +502,7 @@ URLs - this aspect is taken care of in the preferences server component.
      * @return {Function} A transform function for the conversion suitable to
      *     use in fluid.transform.
      */
-    gpii.ontologyHandler.makePreferencesPrefsSetTransform = function (transformSpec) {
+    gpii.ontologyHandler.makePrefsSetTransform = function (transformSpec) {
         return function (prefsSet) {
             // copy values directly or transform - depending on key
             return fluid.transform(prefsSet, function (val, key) {

--- a/testData/preferences/jaws.json5
+++ b/testData/preferences/jaws.json5
@@ -143,9 +143,9 @@
                         "Touch.TapEventDurationMax": 99,
                         "Touch.TapInterEventDurationMax": 99,
                         "Touch.TapTranslationMax": 99
-                    }
-                },
-                "http://registry.gpii.net/applications/com.freedomscientific.jaws/enabled": true
+                    },
+                    "http://registry.gpii.net/applications/com.freedomscientific.jaws/enabled": true
+                }
             }
         }
     }


### PR DESCRIPTION
[The key-in failure](https://issues.gpii.net/browse/GPII-4225) is because in jaws.json5 the definition of the "/enabled" term is outside of the "preferences" block.