### PR TITLE
GPII-4446: Modifying the existing ribbon, rather than replacing it.

### DIFF
--- a/gpii/node_modules/settingsHandlers/src/RemoteFileSettingsHandler.js
+++ b/gpii/node_modules/settingsHandlers/src/RemoteFileSettingsHandler.js
@@ -367,9 +367,11 @@ gpii.settingsHandlers.remoteFileSettingsHandler.transferFile = function (source,
  * }
  *
  * @param {Object} payload The payload.
+ * @param {String} solutionID The solution ID.
+ * @param {Function} componentCreator [optional] The component creator [default: remoteFileSettingsHandler()]
  * @return {Promise} Resolves with the response.
  */
-gpii.settingsHandlers.remoteFileSettingsHandler.setImpl = function (payload) {
+gpii.settingsHandlers.remoteFileSettingsHandler.setImpl = function (payload, solutionID, componentCreator) {
     var promiseTogo = fluid.promise();
 
     var results = {};
@@ -386,7 +388,7 @@ gpii.settingsHandlers.remoteFileSettingsHandler.setImpl = function (payload) {
 
             var options = payload.options.settings[key];
 
-            var remoteFileDownload = gpii.settingsHandlers.remoteFileDownload({
+            var remoteFileDownload = (componentCreator || gpii.settingsHandlers.remoteFileDownload)({
                 members: {
                     cache: options.cache
                 }

--- a/gpii/node_modules/settingsHandlers/src/RemoteFileSettingsHandler.js
+++ b/gpii/node_modules/settingsHandlers/src/RemoteFileSettingsHandler.js
@@ -106,8 +106,13 @@ fluid.defaults("gpii.settingsHandlers.remoteFileDownload", {
             funcName: "gpii.settingsHandlers.remoteFileSettingsHandler.downloadFile",
             args: ["{that}.url", "{that}.downloadPath", "{that}.cache"]
         },
-        "applyFile.stash": {
+        "applyFile.backup": {
             priority: "after:download",
+            funcName: "gpii.settingsHandlers.remoteFileSettingsHandler.createBackup",
+            args: ["{that}.path", "{that}.gpiiSettingsDir"]
+        },
+        "applyFile.stash": {
+            priority: "after:backup",
             funcName: "gpii.settingsHandlers.remoteFileSettingsHandler.transferFile",
             args: ["{that}.path", "{that}.stashPath"]
         },
@@ -292,6 +297,27 @@ gpii.settingsHandlers.remoteFileSettingsHandler.downloadFile = function (url, do
                 });
             }
         });
+    }
+    return promise;
+};
+
+/**
+ * Create a single backup of a file. Target files are copied to the backups subdirectory of the settings directory, the
+ * first time they are updated by this settings handler. This is to allow someone to recover their data from some
+ * known-good point (that is, before Morphic touched it).
+ *
+ * @param {String} originalFile The file to backup.
+ * @param {String} settingsDir The settings directory.
+ * @return {Promise} Resolves when complete.
+ */
+gpii.settingsHandlers.remoteFileSettingsHandler.createBackup = function (originalFile, settingsDir) {
+    var backupPath = path.join(settingsDir, "backups", path.basename(originalFile));
+
+    var promise;
+    if (!fs.existsSync(originalFile) || fs.existsSync(backupPath)) {
+        promise = fluid.promise().resolve();
+    } else {
+        promise = gpii.settingsHandlers.remoteFileSettingsHandler.transferFile(originalFile, backupPath, true);
     }
     return promise;
 };

--- a/gpii/node_modules/settingsHandlers/test/RemoteFileSettingsHandlerTests.js
+++ b/gpii/node_modules/settingsHandlers/test/RemoteFileSettingsHandlerTests.js
@@ -138,9 +138,15 @@ gpii.tests.remoteFileSettingsHandler.cleanDir = function () {
  */
 fluid.defaults("gpii.tests.remoteFileSettingsHandler.testCaseHolder", {
     gradeNames: ["fluid.test.testCaseHolder"],
+    components: {
+        settingsDir: {
+            type: "gpii.settingsDir"
+        }
+    },
     members: {
         downloadTo: path.join(gpii.tests.remoteFileSettingsHandler.testDir, "downloads", "download"),
-        stashDir: path.join(gpii.tests.remoteFileSettingsHandler.testDir, "stash")
+        stashDir: path.join(gpii.tests.remoteFileSettingsHandler.testDir, "stash"),
+        gpiiSettingsDir: "@expand:{settingsDir}.getGpiiSettingsDir()"
     },
     listeners: {
         "onCreate.createDir": {
@@ -250,6 +256,18 @@ fluid.defaults("gpii.tests.remoteFileSettingsHandler.testCaseHolder", {
             ]
         }]
     }, {
+        name: "remoteFileSettingsHandler createBackup",
+        tests: [{
+            name: "createBackup",
+            args: [ gpii.tests.remoteFileSettingsHandler.testDir ],
+            expect: 1,
+
+            task: "gpii.tests.remoteFileSettingsHandler.testBackup",
+            resolve: "gpii.tests.remoteFileSettingsHandler.assertBackup",
+            resolveArgs: [ gpii.tests.remoteFileSettingsHandler.testDir ]
+
+        }]
+    }, {
         name: "remoteFileSettingsHandler download",
         tests: [{
             // First download ensures it's downloaded.
@@ -331,7 +349,7 @@ fluid.defaults("gpii.tests.remoteFileSettingsHandler.testCaseHolder", {
                 expectedFiles: {
                     file1: "file-one.value1"
                 }
-            }],
+            }, "{that}.gpiiSettingsDir"],
             resolve: "fluid.identity"
         }, {
             name: "setting single file, existing",
@@ -369,7 +387,7 @@ fluid.defaults("gpii.tests.remoteFileSettingsHandler.testCaseHolder", {
                 expectedFiles: {
                     file1: "new-content.value1"
                 }
-            }],
+            }, "{that}.gpiiSettingsDir"],
             resolve: "fluid.identity"
         }, {
             name: "setting two files",
@@ -416,7 +434,7 @@ fluid.defaults("gpii.tests.remoteFileSettingsHandler.testCaseHolder", {
                     file1: "new-content1.value1",
                     file2: "new-content2.value2"
                 }
-            }],
+            }, "{that}.gpiiSettingsDir"],
             resolve: "fluid.identity"
         }, {
             name: "setting two files, 1 exists",
@@ -465,7 +483,7 @@ fluid.defaults("gpii.tests.remoteFileSettingsHandler.testCaseHolder", {
                     file1: "new-content1.value1",
                     file2: "new-content2.value2"
                 }
-            }],
+            }, "{that}.gpiiSettingsDir"],
             resolve: "fluid.identity"
         }, {
             name: "setting ten files, half exist, different response times",
@@ -606,7 +624,7 @@ fluid.defaults("gpii.tests.remoteFileSettingsHandler.testCaseHolder", {
                     file9: "new-content9.value9",
                     file10: "new-content10.value10"
                 }
-            }],
+            }, "{that}.gpiiSettingsDir"],
             resolve: "fluid.identity"
         }, {
             name: "setting 1 file, 1 error",
@@ -638,8 +656,10 @@ fluid.defaults("gpii.tests.remoteFileSettingsHandler.testCaseHolder", {
                 },
                 expectedFiles: {
                     file1: "original-content1"
+                },
+                expectedBackups: {
                 }
-            }],
+            }, "{that}.gpiiSettingsDir"],
             resolve: "fluid.identity"
         }, {
             name: "setting 3 files, 1 error",
@@ -688,8 +708,11 @@ fluid.defaults("gpii.tests.remoteFileSettingsHandler.testCaseHolder", {
                 expectedFiles: {
                     file1: "new-content1.value1",
                     file3: "original-content3"
+                },
+                expectedBackups: {
+                    file1: "original-content1"
                 }
-            }],
+            }, "{that}.gpiiSettingsDir"],
             resolve: "fluid.identity"
         }, {
             name: "setting 3 files, 1 error",
@@ -745,12 +768,58 @@ fluid.defaults("gpii.tests.remoteFileSettingsHandler.testCaseHolder", {
                     file1: "new-content1.value1",
                     file2: "original-content2",
                     file3: "new-content3.value3"
+                },
+                expectedBackups: {
+                    file1: "original-content1",
+                    file3: "original-content3"
                 }
-            }],
+            }, "{that}.gpiiSettingsDir"],
             resolve: "fluid.identity"
         }]
     }]
 });
+
+/**
+ * Tests for createBackup.
+ * @param {String} testDir Directory for testing.
+ * @return {Promise} Resolves when complete.
+ */
+gpii.tests.remoteFileSettingsHandler.testBackup = function (testDir) {
+
+    var testFileNotExist = path.join(testDir, "backup-test.not-exist");
+
+    // Create the initial content of the file to back-up.
+    var testFile = path.join(testDir, "backup-test");
+    fs.writeFileSync(testFile, "initial content");
+
+    return fluid.promise.sequence([
+        // No backup should be made
+        gpii.settingsHandlers.remoteFileSettingsHandler.createBackup(testFileNotExist, testDir),
+        // Backup the file
+        gpii.settingsHandlers.remoteFileSettingsHandler.createBackup(testFile, testDir),
+        function () {
+            // Change the content - to check if the original backup gets overwritten.
+            fs.writeFileSync(testFile, "updated content");
+            return gpii.settingsHandlers.remoteFileSettingsHandler.createBackup(testFile, testDir);
+        }
+    ]);
+};
+
+gpii.tests.remoteFileSettingsHandler.assertBackup = function (testDir) {
+    jqUnit.expect(2);
+
+    // Backup of a non existing file should not be made.
+    var testFileNotExist = path.join(testDir, "backups", "backup-test.not-exist");
+    jqUnit.assertFalse("non existing back up file should not exist", fs.existsSync(testFileNotExist));
+
+    // The exising file backup should exist.
+    var testFile = path.join(testDir, "backups", "backup-test");
+    jqUnit.assertTrue("back up file should exist", fs.existsSync(testFile));
+
+    // The content should be the original content, and not overwritten.
+    jqUnit.assertEquals("content of the backup file should be the original",
+        "initial content", fs.readFileSync(testFile, "utf8"));
+};
 
 /**
  * Check that a downloaded file is correct.
@@ -896,14 +965,19 @@ gpii.tests.remoteFileSettingsHandler.invokedValues = null;
 /**
  * Performs an end-to-end test of the remote file settings handler.
  * @param {Object} testData The test data.
+ * @param {String} settingsDir The settings directory.
  * @return {Promise} Resolves when complete.
  */
-gpii.tests.remoteFileSettingsHandler.testSetting = function (testData) {
+gpii.tests.remoteFileSettingsHandler.testSetting = function (testData, settingsDir) {
 
     var promise = fluid.promise();
 
     var dir = path.join(gpii.tests.remoteFileSettingsHandler.testDir, "setting" + Math.random());
     mkdirp.sync(dir);
+
+    // Remove backups from a previous run
+    var backupDir = path.join(settingsDir, "backups");
+    rimraf.sync(backupDir);
 
     // Fix the paths in the payload
     var test = gpii.tests.remoteFileSettingsHandler.fixPath(testData, dir);
@@ -913,10 +987,14 @@ gpii.tests.remoteFileSettingsHandler.testSetting = function (testData) {
         fs.writeFileSync(path.join(dir, file), content);
     });
 
+    // Initial files should be backed up, unless specified otherwise.
+    var expectedBackups = test.expectedBackups || test.initialFiles;
+
     // post-apply/restore file checks
     jqUnit.expect(2 +
         (Object.keys(test.expectedFiles).length * 2 + 1) +
-        (Object.keys(test.initialFiles).length * 2 + 1));
+        (Object.keys(test.initialFiles).length * 2 + 1) +
+        (Object.keys(expectedBackups).length * 2));
 
     // Record the before/after invokes
     gpii.tests.remoteFileSettingsHandler.invokedValues = {};
@@ -955,6 +1033,15 @@ gpii.tests.remoteFileSettingsHandler.testSetting = function (testData) {
             // Check the custom invokers were hit
             jqUnit.assertDeepEq("custom invokers should have been invoked as expected",
                 test.expectedInvokes || {}, gpii.tests.remoteFileSettingsHandler.invokedValues);
+
+            // Ensure file backups had been made
+            fluid.each(expectedBackups, function (content, file) {
+                var backupFile = path.join(backupDir, file);
+                jqUnit.assertTrue("Backup file for " + file + " should exist.", fs.existsSync(backupFile));
+                jqUnit.assertEquals("Backup file for " + file + " should be the correct content.",
+                    content, fs.readFileSync(backupFile, "utf8"));
+            });
+
             promise.resolve();
         });
     });

--- a/testData/solutions/win32.json5
+++ b/testData/solutions/win32.json5
@@ -16242,7 +16242,7 @@
                 }
             },
             "configure.ribbons": {
-                "type": "gpii.settingsHandlers.remoteFileSettingsHandler",
+                "type": "gpii.settingsHandlers.remoteFileSettingsHandler.office",
                 "liveness": "live",
                 "options": {
                     "settings": {


### PR DESCRIPTION
Required by https://github.com/GPII/windows/pull/313, this allows the component used by the remoteFileSettingsHandler to be replaced.

Added bonus of creating a backup of original files which are about to be replaced.