### PR TITLE
FLUID-6486: vagrant: Use Fedora 31 box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,7 @@ ram = ENV["VM_RAM"] || 2048
 
 Vagrant.configure(2) do |config|
 
-  config.vm.box = "inclusivedesign/fedora28"
+  config.vm.box = "inclusivedesign/fedora31"
 
   # Your working directory will be synced to /home/vagrant/sync in the VM.
   config.vm.synced_folder ".", "#{app_directory}"


### PR DESCRIPTION
Fedora 28 has reached end-of-life (EOL) on May 2019.

https://fedoraproject.org/wiki/End_of_life