### PR TITLE
typo fix:README.md added "an" before untrusted .

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The Flow Manager with the `gpii.config.cloudBased.flowManager.production` config
  preferences (default: `http://localhost:8081`)
 * `GPII_DATASOURCE_HOSTNAME`: The host name of CouchDB (default: `http://localhost`)
 * `GPII_DATASOURCE_PORT`: The port of CouchDB (default: 5984)
-* `GPII_CLOUD_URL`: The URL to GPII Cloud (default: `http://localhost:8084`). Used by untrusted local flow manager
+* `GPII_CLOUD_URL`: The URL to GPII Cloud (default: `http://localhost:8084`). Used by an untrusted local flow manager
  to communicate with GPII Cloud.
 
 #### Example:


### PR DESCRIPTION
fix issue - #864 
typo fix: added "an" before untrusted  in flow manager.