### PR TITLE
GPII-4087: Removed gpii.windows.rm references from SR

### DIFF
--- a/gpii/node_modules/testing/src/Mocks.js
+++ b/gpii/node_modules/testing/src/Mocks.js
@@ -633,16 +633,6 @@ gpii.test.integration.mockActionHandlers.resolveName = function (that, name) {
 fluid.defaults("gpii.test.integration.mockActionHandlers.windows", {
     gradeNames: "gpii.test.integration.mockActionHandlers",
     mockActionHandlers: {
-        "gpii.windows.rm": {
-            mockFunc: "fluid.identity",
-            defaults: {
-                gradeNames: "fluid.function",
-                argumentMap: {
-                    path: 0,
-                    options: 1
-                }
-            }
-        },
         "gpii.windows.spiSettingsHandler.setHighContrastTheme": {
             mockFunc: "fluid.identity",
             defaults: {

--- a/testData/solutions/win32.json5
+++ b/testData/solutions/win32.json5
@@ -6789,22 +6789,6 @@
             }
         },
         "configure": [
-            // Remove current system wallpaper files.
-            {
-                "type": "gpii.windows.rm",
-                "path": "${{environment}.APPDATA}\\Microsoft\\Windows\\Themes\\CachedFiles",
-                "options": {
-                    "recursive": true,
-                    "silent": true
-                }
-            },
-            {
-                "type": "gpii.windows.rm",
-                "path": "${{environment}.APPDATA}\\Microsoft\\Windows\\Themes\\TranscodedWallpaper",
-                "options": {
-                    "silent": true
-                }
-            },
             // Set the "restore" theme.
             "settings.configure-theme",
             // Set the high-contrast theme.


### PR DESCRIPTION
This PR removes the references to `gpii.windows.rm` following the review of https://github.com/GPII/windows/pull/276 and according to [this comment](https://github.com/GPII/windows/pull/276#issuecomment-523447922).