### PR TITLE
GPII-4500: Fixed the "preference" metric.

### DIFF
--- a/gpii/node_modules/eventLog/src/metrics.js
+++ b/gpii/node_modules/eventLog/src/metrics.js
@@ -110,7 +110,7 @@ fluid.defaults("gpii.metrics.lifecycle", {
         }
     },
     listeners: {
-        "{lifecycleManager}.events.onCreate": {
+        "onCreate": {
             namespace: "trackPrefsSetChange",
             listener: "gpii.metrics.trackPrefsSetChange",
             args: ["{that}", "{lifecycleManager}"]
@@ -222,7 +222,7 @@ gpii.metrics.preferenceChanged = function (that, current, previous) {
         fluid.each(changedPreferences, function (value, name) {
             that.logMetric("preference", {
                 name: name,
-                newValue: value.toString()
+                setTo: fluid.isPrimitive(value) ? value.toString() : value
             });
         });
     }


### PR DESCRIPTION
Metric is captured when a preference has been applied.

From the `snapset_2B` preference set:
```JSON5
{
    module: "metrics",
    event: "preference",
    data: {
        name: "http://registry.gpii.net/common/cursorSize",
        setTo: "1"
    }
}
{
    module: "metrics",
    event: "preference",
    data: {
        name: "http://registry.gpii.net/common/DPIScale",
        setTo: "2"
    }
}
{
    module: "metrics",
    event: "preference",
    data: {
        name: "http://registry.gpii.net/common/highContrastTheme",
        setTo: "white-black"
    }
}
```