### PR TITLE
GPII-4510 SoundSentry is showing up as REG_SZ in regedit, and despite…

### DIFF
--- a/testData/preferences/sally.json5
+++ b/testData/preferences/sally.json5
@@ -18,7 +18,7 @@
                 "name": "Default preferences",
                 "preferences": {
                     "http://registry.gpii.net/applications/com.microsoft.windows.soundSentry": {
-                        "WindowsEffect": 2
+                        "WindowsEffect": "2"
                     }
                 }
             }

--- a/testData/solutions/win32.json5
+++ b/testData/solutions/win32.json5
@@ -29387,7 +29387,7 @@
                     "hKey": "HKEY_CURRENT_USER",
                     "path": "Control Panel\\Accessibility\\SoundSentry",
                     "dataTypes": {
-                        "WindowsEffect": "REG_DWORD"
+                        "WindowsEffect": "REG_SZ"
                     }
                 },
                 "supportedSettings": {
@@ -29396,10 +29396,10 @@
                             "title": "SoundSentry",
                             "description": "Selects the desired visual notification for sounds.",
                             "enum": [
-                                0,
-                                1,
-                                2,
-                                3
+                                "0",
+                                "1",
+                                "2",
+                                "3"
                             ],
                             "enumLabels": [
                                 "No visual alert",

--- a/tests/data/preferences/os_win.json5
+++ b/tests/data/preferences/os_win.json5
@@ -263,7 +263,7 @@
                         "Dock": 0
                     },
                     "http://registry.gpii.net/applications/com.microsoft.windows.soundSentry": {
-                        "WindowsEffect": 2
+                        "WindowsEffect": "2"
                     },
                     "http://registry.gpii.net/applications/com.microsoft.windows.volumeControl": {
                         "Volume": {

--- a/tests/platform/windows/windows-builtIn-testSpec.js
+++ b/tests/platform/windows/windows-builtIn-testSpec.js
@@ -720,13 +720,13 @@ gpii.tests.windows.builtIn = [
                 }],
                 "com.microsoft.windows.soundSentry": [{
                     "settings": {
-                        "WindowsEffect": 2
+                        "WindowsEffect": "2"
                     },
                     "options": {
                         "hKey": "HKEY_CURRENT_USER",
                         "path": "Control Panel\\Accessibility\\SoundSentry",
                         "dataTypes": {
-                            "WindowsEffect": "REG_DWORD"
+                            "WindowsEffect": "REG_SZ"
                         }
                     }
                 }],


### PR DESCRIPTION
GPII-4510 SoundSentry is showing up as REG_SZ in regedit, and despite being numbers, these are saved as strings in the registry.