### PR TITLE
Replace link to wiki with link to archive on WayBack Machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 The package contains cross-platform core components of the GPII personalization infrastructure. This repository should
 not be used directly, but in conjunction with one of the top-level GPII architecture-specific repositories.
-Additional documentation is available [on our wiki](http://wiki.gpii.net/w/Architecture).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 The package contains cross-platform core components of the GPII personalization infrastructure. This repository should
 not be used directly, but in conjunction with one of the top-level GPII architecture-specific repositories.
+Additional documentation is available [in an archived version of our wiki](https://web.archive.org/web/20200807234452/http://wiki.gpii.net/w/Architecture).
 
 ## Installation
 


### PR DESCRIPTION
The wiki at wiki.gpii.net is no longer online, so the link points to nowhere.